### PR TITLE
fix(react-components): `withConfig` error handle & adjusting output configuration (esm/cjs)

### DIFF
--- a/packages/react-components/.babelrc.js
+++ b/packages/react-components/.babelrc.js
@@ -1,4 +1,5 @@
 const isProduction = process.env.NODE_ENV === 'production'
+const buildTarget = process.env.BUILD_TARGET || 'esmodule' // another value could be 'commonjs'
 
 export default {
   presets: [
@@ -7,7 +8,7 @@ export default {
       // Compile to npm packages run on Node 14+
       // We can overwrite this option at each package level
       {
-        modules: false,
+        modules: buildTarget === 'esmodule' ? false : 'commonjs',
         targets: {
           node: '14',
         },

--- a/packages/react-components/Makefile
+++ b/packages/react-components/Makefile
@@ -9,8 +9,11 @@ dev:
 	NODE_ENV=development yarn webpack serve -c dev/webpack.config.js
 
 build-lib:
-	@echo "$(P) Transpile es6, jsx and (typescript) to es5"
-	NODE_ENV=production yarn babel src --out-dir lib --copy-files
+	mkdir -p lib
+	BUILD_TARGET=esmodule NODE_ENV=production yarn babel src --out-dir lib/esm --copy-files
+	echo '{ "type": "module" }' > lib/esm/package.json 
+	BUILD_TARGET=commonjs NODE_ENV=production yarn babel src --out-dir lib/cjs --copy-files
+	echo '{ "type": "commonjs" }' > lib/cjs/package.json 
 
 
 build: clean build-lib

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,9 +1,14 @@
 {
   "name": "@readr-media/react-component",
-  "version": "1.0.1",
+  "version": "1.0.2-beta.23",
   "description": "",
-  "main": "lib/index.js",
+  "main": "lib/cjs/index.js",
+  "module": "lib/esm/index.js",
   "type": "module",
+  "exports": {
+    "import": "./lib/esm/index.js",
+    "require": "./lib/cjs/index.js"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "make dev",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -30,9 +30,6 @@
   ],
   "author": "xuanchang",
   "license": "MIT",
-  "dependencies": {
-    "styled-components": "^5.3.5"
-  },
   "peerDependencies": {
     "react": "^18.1.0",
     "react-dom": "^18.1.0",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readr-media/react-component",
-  "version": "1.0.2-beta.23",
+  "version": "1.0.2-beta.32",
   "description": "",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/packages/react-components/src/donate-button/index.js
+++ b/packages/react-components/src/donate-button/index.js
@@ -1,5 +1,5 @@
 import React from 'react' // eslint-disable-line
-import styled from 'styled-components'
+import styled from '../styled-components.js'
 
 const Button = styled.a`
   font-family: 'Source Han Sans Traditional', sans-serif;

--- a/packages/react-components/src/logo/index.js
+++ b/packages/react-components/src/logo/index.js
@@ -1,5 +1,5 @@
 import React from 'react' // eslint-disable-line
-import styled from 'styled-components'
+import styled from '../styled-components.js'
 
 import { ReadrIcon } from './react-components/icon.js'
 

--- a/packages/react-components/src/related-report/index.js
+++ b/packages/react-components/src/related-report/index.js
@@ -1,5 +1,5 @@
 import React from 'react' // eslint-disable-line
-import styled from 'styled-components'
+import styled from '../styled-components.js'
 import RelatedList from './react-components/related-list.js'
 
 const Container = styled.section`

--- a/packages/react-components/src/related-report/react-components/related-list.js
+++ b/packages/react-components/src/related-report/react-components/related-list.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react' // eslint-disable-line
-import styled from 'styled-components'
+import styled from '../../styled-components.js'
 import DefaultImage from './image/default-image.js'
 import ReportInfo from './report-info.js'
 

--- a/packages/react-components/src/related-report/react-components/report-info.js
+++ b/packages/react-components/src/related-report/react-components/report-info.js
@@ -1,5 +1,5 @@
 import React from 'react' // eslint-disable-line
-import styled from 'styled-components'
+import styled from '../../styled-components.js'
 import { formattedDate } from './utils.js'
 
 const DotStyle = `

--- a/packages/react-components/src/styled-components.js
+++ b/packages/react-components/src/styled-components.js
@@ -1,0 +1,7 @@
+import styled from 'styled-components'
+
+export * from 'styled-components'
+
+const defaultStyled = typeof styled === 'function' ? styled : styled.default
+
+export { defaultStyled as default }

--- a/packages/react-components/src/subscribe-button/index.js
+++ b/packages/react-components/src/subscribe-button/index.js
@@ -1,5 +1,5 @@
 import React from 'react' // eslint-disable-line
-import styled from 'styled-components'
+import styled from '../styled-components.js'
 
 const Button = styled.a`
   font-family: 'Source Han Sans Traditional', sans-serif;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5734,22 +5734,6 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
-styled-components@^5.3.5:
-  version "5.3.8"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.3.8.tgz#b92e2d10352dc9ecf3b1bc5d27c7500832dcf870"
-  integrity sha512-6jQrlvaJQ16uWVVO0rBfApaTPItkqaG32l3746enNZzpMDxMvzmHzj8rHUg39bvVtom0Y8o8ZzWuchEXKGjVsg==
-  dependencies:
-    "@babel/helper-module-imports" "^7.0.0"
-    "@babel/traverse" "^7.4.5"
-    "@emotion/is-prop-valid" "^1.1.0"
-    "@emotion/stylis" "^0.8.4"
-    "@emotion/unitless" "^0.7.4"
-    babel-plugin-styled-components ">= 1.12.0"
-    css-to-react-native "^3.0.0"
-    hoist-non-react-statics "^3.0.0"
-    shallowequal "^1.1.0"
-    supports-color "^5.5.0"
-
 styled-components@^5.3.6:
   version "5.3.6"
   resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.3.6.tgz#27753c8c27c650bee9358e343fc927966bfd00d1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5734,6 +5734,22 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
+styled-components@^5.3.5:
+  version "5.3.8"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.3.8.tgz#b92e2d10352dc9ecf3b1bc5d27c7500832dcf870"
+  integrity sha512-6jQrlvaJQ16uWVVO0rBfApaTPItkqaG32l3746enNZzpMDxMvzmHzj8rHUg39bvVtom0Y8o8ZzWuchEXKGjVsg==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/traverse" "^7.4.5"
+    "@emotion/is-prop-valid" "^1.1.0"
+    "@emotion/stylis" "^0.8.4"
+    "@emotion/unitless" "^0.7.4"
+    babel-plugin-styled-components ">= 1.12.0"
+    css-to-react-native "^3.0.0"
+    hoist-non-react-statics "^3.0.0"
+    shallowequal "^1.1.0"
+    supports-color "^5.5.0"
+
 styled-components@^5.3.6:
   version "5.3.6"
   resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.3.6.tgz#27753c8c27c650bee9358e343fc927966bfd00d1"


### PR DESCRIPTION
## 問題描述
- [`@readr-media/react-component`](https://www.npmjs.com/package/@readr-media/react-component) 元件使用於 Next.js 時，會出現 `withConfig` undefined error。
- 如使用於 client-side 環境（ex: React)，或是於套件環境執行 `yarn dev` 時，並不會出現上述錯誤。
- 註：當執行 `yarn build`、 styled-components 透過 babel 設定轉換時，`withConfig` 會出現於 `lib` 中。（不管 babel exports modules 設定為 `commonjs` 或 `ES modules`，都會有 `withConfig`。）
<img width="400" alt="截圖 2023-03-09 下午12 47 57" src="https://user-images.githubusercontent.com/104489150/224230841-a907a47e-7e48-4996-bb80-105ea340f9cd.png">
<img width="400" alt="截圖 2023-03-09 下午12 54 13" src="https://user-images.githubusercontent.com/104489150/224231101-1bee20a6-76b1-44b7-abd3-7f173bf515de.png">

## 套件背景說明
- `@readr-media/react-component` 的 `package.json` 設定為 `type: module`，因此套件本身使用 ESM 撰寫，且 babel exports modules 設定為 `false`，因此 `yarn publish` 後的 `lib` 內容為 ESM 格式。
- 此套件當初預設使用環境須為 Node.js 12 / Next.js 12 以上。


## 相關調整
- 討論過程中，因為推測可能是使用 `lib` 中 ESM 格式資料下，才會出現 `withConfig` 錯誤，因此有一併討論：當套件環境設定為 `type:module` 的狀況下，可以如何同時 export 具有 `esm` 與 `cjs` 格式的 `lib` 內容，讓不支援 esm 格式的專案環境，也可以使用此套件。
- 調整目標：讓 `lib` 內有 `esm` 與 `cjs` 資料夾，讓專案依照需求與該撰寫環境各自取用。

### Makefile 
- 指定 `BUILD_TARGET` 變數，以生成 `lib/esm`與 `lib/cjs` 資料夾，並生成對應的 `package.json` 內容。
- `package.json` 中的  `'{ "type": " " }` 會去轉換套件內元件資料格式為 ESM or commonJS。

### babelrc 
- 透過 `BUILD_TARGET` 此環境變數，去動態設定 babel export 的 `modules` 格式。
```
   modules: buildTarget === 'esmodule' ? false : 'commonjs',
```
### package.json
- 設定當專案使用環境透過 `import` 來使用套件，會取用 `"./lib/esm/index.js"` 的 ESM 格式資料。
- 設定當專案使用環境透過 `require` 來使用套件，會取用 `"./lib/cjs/index.js"` 的 commonJS 格式資料。
```
  "exports": {
    "import": "./lib/esm/index.js",
    "require": "./lib/cjs/index.js"
  },
```
- `"main"`：設定在 commonJS 環境下，該套件被使用的 entry path。
- `"module"`：設定在 ESM 環境下，該套件被使用的 entry path。
```
 "main": "lib/cjs/index.js",
 "module": "lib/esm/index.js",
```

## 調整測試
- 經過上述更動後，目前於 `@readr-media/react-component` 中的 `lib` 內會具有 `esm` 與 `cjs` 資料內容。
- 實際於 Next 環境測試，如果透過 `import`，使用 `esm` 內資料，依舊會遇到 `withConfig` error。
```
import { SubscribeButton } from '@readr-media/react-component'
```
- 測試上如果透過 `require`，使用 `cjs` 內資料，則不會有報錯。（此方法僅作為測試，不建議使用）
```
const { SubscribeButton } = require('@readr-media/react-component');
```

## 小結
- 目前推測可能是 `styled-components` 或是 `babel-plugin-styled-components` 在針對 ES modules 的功能支援上有問題，導致透過 babel 轉換時，`withConfig` 被偵測為沒有一併 export，導致專案出現 `withConfig undefined error`，導致無法使用格式為 ESM 的 styled-components 相關內容。
- 上述修改雖然同時 export `esm` 與 `cjs` 資料內容，但經過測試 `esm` 目前無法使用於 SSR 環境。因此在實用性上，套件內如果有使用到 styled-components，則 `esm` 此資料夾也無法被使用（因為使用了就會報錯），僅能透過其餘設定使用 `cjs` 資料。
- 但如果套件本身沒有使用到 `styled-components`，則不受上述影響，且可參考此 PR 進行套件優化。 