### PR TITLE
fix(react-components): `relatedData` error handle 

### DIFF
--- a/packages/react-components/dev/mock-reports.js
+++ b/packages/react-components/dev/mock-reports.js
@@ -1,32 +1,70 @@
 export const reportsData = [
   {
     id: 1,
-    caption:
-      '【寵粉速報】5元就能訂閱「鏡週刊會員制」【寵粉速報】5元就能訂閱「鏡週刊會員制」',
-    imageUrl:
-      'https://www.mirrormedia.com.tw/assets/images/20221017214008-027f6c46502e220dd63521d758ef95e6.jpg',
-    alt: 'report01',
-    date: '2023-02-08T07:00:00.000Z',
-    time: 15,
-    link: `https://www.readr.tw/post/2928`,
+    name: '【寵粉速報】5元就能訂閱「鏡週刊會員制」【寵粉速報】5元就能訂閱「鏡週刊會員制」',
+    heroImage: {
+      id: '6',
+      name: '看板追追追 2.0',
+      resized: {
+        original:
+          'https://www.readr.tw/assets/images/cld2ymzdw000p10ykb7pshoop-mobile.png',
+        w480: '',
+        w800: 'https://www.readr.tw/assets/images/cld2ymzdw000p10ykb7pshoop-mobile.png',
+        w1200:
+          'https://www.readr.tw/assets/images/cld2ymzdw000p10ykb7pshoop-mobile.png',
+        w1600:
+          'https://www.readr.tw/assets/images/cld2ymzdw000p10ykb7pshoop-mobile.png',
+        w2400:
+          'https://www.readr.tw/assets/images/cld2ymzdw000p10ykb7pshoop-mobile.png',
+      },
+    },
+
+    readingTime: 5,
   },
   {
     id: 2,
-    caption:
-      '【寵粉速報】5元就能訂閱「鏡週刊會員制」　年費會員加碼抽Sony旗艦手機',
-    imageUrl:
-      'https://www.mirrormedia.com.tw/assets/images/20221017214008-027f6c46502e220dd63521d758ef95e6.jpg',
-    alt: 'report02',
-    link: 'https://www.readr.tw/post/2931',
-    date: '2022-02-08T07:00:00.000Z',
-    time: 10,
+    name: '【寵粉速報】5元就能訂閱「鏡週刊會員制」【寵粉速報】5元就能訂閱「鏡週刊會員制」',
+    heroImage: {
+      id: '6',
+      name: '看板追追追 2.0',
+      resized: {
+        original:
+          'https://www.readr.tw/assets/images/clckhy1qz001310xb2u888w1d-mobile.png',
+        w480: '',
+        w800: 'https://www.readr.tw/assets/images/clckhy1qz001310xb2u888w1d-mobile.png',
+        w1200:
+          'https://www.readr.tw/assets/images/clckhy1qz001310xb2u888w1d-mobile.png',
+        w1600:
+          'https://www.readr.tw/assets/images/clckhy1qz001310xb2u888w1d-mobile.png',
+        w2400:
+          'https://www.readr.tw/assets/images/clckhy1qz001310xb2u888w1d-mobile.png',
+      },
+    },
+
+    readingTime: 15,
+    publishTime: '2023-02-08T07:00:00.000Z',
   },
   {
     id: 3,
-    caption: '【寵粉速報】5元就能訂閱「鏡週刊會員制」　年費會員加碼',
-    alt: 'report03',
-    date: '2021-02-08T07:00:00.000Z',
-    time: 5,
-    link: 'https://www.readr.tw/post/2903',
+    name: '【寵粉速報】5元就能訂閱「鏡週刊會員制」【寵粉速報】5元就能訂閱「鏡週刊會員制」',
+    heroImage: {
+      id: '6',
+      name: '看板追追追 2.0',
+      resized: {
+        original:
+          'https://storage.googleapis.com/statics-readr-tw-dev/images/5f4cdc4f2f0f930023f79aae-w2400.看板追追追2.0.jpeg',
+        w480: 'https://storage.googleapis.com/statics-readr-tw-dev/images/5f4cdc4f2f0f930023f79aae-w2400.看板追追追2.0.jpeg',
+        w800: 'https://storage.googleapis.com/statics-readr-tw-dev/images/5f4cdc4f2f0f930023f79aae-w2400.看板追追追2.0.jpeg',
+        w1200:
+          'https://storage.googleapis.com/statics-readr-tw-dev/images/5f4cdc4f2f0f930023f79aae-w2400.看板追追追2.0.jpeg',
+        w1600:
+          'https://storage.googleapis.com/statics-readr-tw-dev/images/5f4cdc4f2f0f930023f79aae-w2400.看板追追追2.0.jpeg',
+        w2400:
+          'https://storage.googleapis.com/statics-readr-tw-dev/images/5f4cdc4f2f0f930023f79aae-w2400.看板追追追2.0.jpeg',
+      },
+    },
+
+    readingTime: 0,
+    publishTime: '2023-02-08T07:00:00.000Z',
   },
 ]

--- a/packages/react-components/src/related-report/index.js
+++ b/packages/react-components/src/related-report/index.js
@@ -95,7 +95,7 @@ const TitleBlock = styled.div`
  */
 
 export default function RelatedReport({
-  relatedData = [],
+  relatedData,
   ariaLevel,
   title = '最新報導',
   titleClassName = 'readr-report-title',
@@ -103,18 +103,19 @@ export default function RelatedReport({
   highlightColor = '#ffffff',
   defaultImage = '',
 }) {
-  const checkCaptionValid = (data) => {
-    return data.every(
-      (obj) => obj.hasOwnProperty('caption') && obj['caption'] !== ''
-    )
+
+  const checkNameValid = (data) => {
+    return data.every((obj) => obj.hasOwnProperty('name') && obj['name'] !== '')
   }
   const checkDataValid = (data) => {
     try {
+      //check：if `relatedData` is an array
       if (!Array.isArray(data)) {
         return false
-      } else if (!checkCaptionValid(data)) {
+      } else if (!checkNameValid(data)) {
+        //check：each object in `relatedData` contains `name` key
         console.log(
-          `Error: Not all objects in 'relatedData' have the key 'caption'`
+          `Error: Not all objects in 'relatedData' have the key 'name'`
         )
         return false
       } else {
@@ -125,6 +126,7 @@ export default function RelatedReport({
       return false
     }
   }
+
 
   return (
     <>

--- a/packages/react-components/src/related-report/react-components/related-list.js
+++ b/packages/react-components/src/related-report/react-components/related-list.js
@@ -8,17 +8,14 @@ const RelatedItem = styled.li`
   width: 100%;
   margin: 0 0 16px;
   cursor: pointer;
-
   > a {
     text-decoration: none;
     color: #000928;
     display: flex;
   }
-
   @media (min-width: 576px) {
     margin: 0 0 32px;
     width: calc(50% - 12px);
-
     > a {
       display: block;
     }
@@ -26,7 +23,6 @@ const RelatedItem = styled.li`
   @media (min-width: 960px) {
     margin: 0 0 60px;
   }
-
   @media (min-width: 1200px) {
     width: calc(25% - 18px);
   }
@@ -41,7 +37,6 @@ const ImgBlock = styled.figure`
   margin: 0 16px 0 0;
   overflow: hidden;
   background: #f4ebfe;
-
   img,
   svg {
     width: 100%;
@@ -50,12 +45,10 @@ const ImgBlock = styled.figure`
     object-position: center;
     -o-transition: all 0.3s ease;
     transition: all 0.3s ease;
-
     &:hover {
       transform: scale(1.1);
     }
   }
-
   @media (min-width: 576px) {
     width: 100%;
     aspect-ratio: 1.9 / 1;
@@ -65,12 +58,19 @@ const ImgBlock = styled.figure`
   }
 `
 
-function ReportImage({ imgSrc, postAmount, alt }) {
-  const [errored, setErrored] = useState(false)
+function ReportImage({ imgSrc, postAmount, alt, defaultImage }) {
+  const [imgErrored, setImgErrored] = useState(false)
+  const [defaultImgErrored, setDefaultImgErrored] = useState(false)
+
   return (
     <ImgBlock amount={postAmount}>
-      {imgSrc && !errored ? (
-        <img src={imgSrc} onError={() => setErrored(true)} alt={alt} />
+      {imgSrc && !imgErrored ? (
+        <img src={imgSrc} onError={() => setImgErrored(true)} alt={alt} />
+      ) : defaultImage && !defaultImgErrored ? (
+        <img
+          src={defaultImage}
+          onError={() => setDefaultImgErrored(true)}
+        ></img>
       ) : (
         <DefaultImage />
       )}
@@ -95,14 +95,15 @@ export default function RelatedList({
             <a href={item.link} target="_blank" rel="noopener noreferrer">
               <ReportImage
                 postAmount={relatedData.length}
-                imgSrc={item.imageUrl ? item.imageUrl : defaultImage}
-                alt={item.alt}
+                imgSrc={item.heroImage?.resized?.original}
+                alt={item.alt || item.heroImage?.name}
+                defaultImage={defaultImage}
               />
               <ReportInfo
-                caption={item.caption}
+                caption={item.name}
                 captionClassName={captionClassName}
-                date={item.date}
-                time={item.time}
+                date={item.publishTime}
+                time={item.readingTime}
               />
             </a>
           </RelatedItem>

--- a/packages/react-components/src/related-report/react-components/report-info.js
+++ b/packages/react-components/src/related-report/react-components/report-info.js
@@ -63,7 +63,7 @@ export default function ReportInfo({ caption, captionClassName, date, time }) {
       {caption && <Caption className={captionClassName}>{caption}</Caption>}
       <Info date={date}>
         {date && <span className="date">{formattedDate(date)}</span>}
-        {time && (
+        {time > 0 && (
           <span className="time">閱讀時間&thinsp;{time}&thinsp;分鐘</span>
         )}
       </Info>


### PR DESCRIPTION
### 新增
- `relatedData` error habdle：
   -  無傳入`relatedData` array 時，`related-post` 區塊不顯示 + 錯誤訊息。
   -  任一報導 缺少 `name` 值時， `related-post` 區塊不顯示 + 錯誤訊息。
   -  缺少 `publishTime`  (報導時間) 時，相應區塊不顯示。
   -  缺少 `readingTime` (閱讀時間) 、或數值 =< 0 時，相應區塊不顯示。
- 使用者填入之 `defaultImage` 和 元件預設圖片 error handle。
- `relatedData` 內要求的 key 值規範，調整為對應 Readr CMS 的欄位名稱/格式，減少前端資料處理程序。


### 更新
- `mock-reports` 測試資料。
- `related-post` 元件 `README` 內容。