### PR TITLE
feat(react-components): add props `postClickHandler` & bump up version to `2.1.0-alpha.1`

### DIFF
--- a/packages/react-components/dev/entry.js
+++ b/packages/react-components/dev/entry.js
@@ -22,6 +22,10 @@ const Header = styled.div`
   margin-bottom: 50px;
 `
 
+const PostClick = (post) => {
+  console.log(post.name)
+}
+
 root.render(
   <>
     <Header>
@@ -51,6 +55,7 @@ root.render(
       headerClassName="自訂headerClassName"
       titleClassName="自訂titleClassName"
       highlightColor="red"
+      postClickHandler={PostClick}
     />
   </>
 )

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readr-media/react-component",
-  "version": "2.0.0-alpha.5",
+  "version": "2.1.0-alpha.1",
   "description": "",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/packages/react-components/src/related-report/README.md
+++ b/packages/react-components/src/related-report/README.md
@@ -16,6 +16,7 @@
   - 使用者可傳入 `defaultImage`。當文章圖片無法正常顯示時，會改為顯示此 `defaultImage`。
   - 使用預設的 className : `.report-header`, `.report-title` 調整大標/報導標題樣式，或傳入自訂 className，並以該 className 進行調整。
   - 傳入 `rwd`, `breakpoint`，設定報導圖片的螢幕斷點與相應的圖片尺寸。（細節可參考 `@readr-media/react-image` 套件設定)。
+  - 可傳入 `postClickHandler`，設定單篇報導 onClick 事件。（注意：`postClickHandler` Function 接收的參數，固定為單篇報導的 post 資料。）
 
 ![Related report](./imgs/related-report.svg)
 
@@ -47,6 +48,10 @@ const data = [
 
 ]
 
+const PostClick = (post) => {
+  console.log(post.name)
+}
+
 export default function ComponentName() {
   return (
     <RelatedReport
@@ -57,6 +62,7 @@ export default function ComponentName() {
       headerClassName="自訂headerClassName"
       titleClassName="自訂titleClassName"
       highlightColor="red"
+      postClickHandler={PostClick}
     />
   )
 }
@@ -64,17 +70,18 @@ export default function ComponentName() {
 
 ## Props
 
-| 名稱            | 資料型別 | 必須 | 預設值                     | 說明                                                                                                                                                                                                          |
-| --------------- | -------- | ---- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| postData        | Array    | `V`  | `[]`                       | 報導資訊。細節見 [postData](#props-detail--postdata)                                                                                                                                                          |
-| header          | string   |      | `"最新報導"`               | 大標。                                                                                                                                                                                                        |
-| ariaLevel       | number   |      | `undefined`                | 設定大標（role="heading"）的 aria-level，                                                                                                                                                                     |
-| highlightColor  | string   |      | `"#ffffff"`                | 標題 highlight 顏色。                                                                                                                                                                                         |
-| headerClassName | string   |      | `"report-header"`          | 指定大標 className，可用於變更大標樣式。                                                                                                                                                                      |
-| titleClassName  | string   |      | `"report-title"`           | 指定報導標題 className，可用於變更報導標題樣式。                                                                                                                                                              |
-| defaultImage    | string   |      | `""`                       | 報導的預設圖片路徑。當 `postData` 的 `images` 載入失敗時，則載入預設圖片。                                                                                                                                    |
-| rwd             | Object   |      | `READr_DEFAULT_RWD`        | [`@readr-media/react-image`](https://www.npmjs.com/package/@readr-media/react-image) 套件參數，設定不同斷點下要載入的圖片大小。 如未填入，設定同 [READr_DEFAULT_RWD](#readr3.0-breakpoint--readr_default_rwd) |
-| breakpoint      | Object   |      | `READr_DEFAULT_BREAKPOINT` | [`@readr-media/react-image`](https://www.npmjs.com/package/@readr-media/react-image) 套件參數，設定螢幕斷點。如未填入，設定同 [READr_DEFAULT_BREAKPOINT](#readr3.0-breakpoint--readr_default_breakpoint) 。   |
+| 名稱             | 資料型別          | 必須 | 預設值                     | 說明                                                                                                                                                                                                          |
+| ---------------- | ----------------- | ---- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| postData         | Array             | `V`  | `[]`                       | 報導資訊。細節見 [postData](#props-detail--postdata)                                                                                                                                                          |
+| header           | string            |      | `"最新報導"`               | 大標。                                                                                                                                                                                                        |
+| ariaLevel        | number            |      | `undefined`                | 設定大標（role="heading"）的 aria-level，                                                                                                                                                                     |
+| highlightColor   | string            |      | `"#ffffff"`                | 標題 highlight 顏色。                                                                                                                                                                                         |
+| headerClassName  | string            |      | `"report-header"`          | 指定大標 className，可用於變更大標樣式。                                                                                                                                                                      |
+| titleClassName   | string            |      | `"report-title"`           | 指定報導標題 className，可用於變更報導標題樣式。                                                                                                                                                              |
+| defaultImage     | string            |      | `""`                       | 報導的預設圖片路徑。當 `postData` 的 `images` 載入失敗時，則載入預設圖片。                                                                                                                                    |
+| rwd              | Object            |      | `READr_DEFAULT_RWD`        | [`@readr-media/react-image`](https://www.npmjs.com/package/@readr-media/react-image) 套件參數，設定不同斷點下要載入的圖片大小。 如未填入，設定同 [READr_DEFAULT_RWD](#readr3.0-breakpoint--readr_default_rwd) |
+| breakpoint       | Object            |      | `READr_DEFAULT_BREAKPOINT` | [`@readr-media/react-image`](https://www.npmjs.com/package/@readr-media/react-image) 套件參數，設定螢幕斷點。如未填入，設定同 [READr_DEFAULT_BREAKPOINT](#readr3.0-breakpoint--readr_default_breakpoint) 。   |
+| postClickHandler | MouseEventHandler |      | `() => {}`                 | 點擊單篇報導後觸發的 Function，接收參數固定為單篇報導的 post 資料。                                                                                                                                           |
 
 ## Props Detail : postData
 

--- a/packages/react-components/src/related-report/index.js
+++ b/packages/react-components/src/related-report/index.js
@@ -110,6 +110,7 @@ const TitleBlock = styled.div`
  * @param {string}      [props.defaultImage='']
  * @param {import('@readr-media/react-image/dist/react-components').Rwd}         [props.rwd]
  * @param {import('@readr-media/react-image/dist/react-components').Breakpoint}  [props.breakpoint]
+ * @param {import("react").MouseEventHandler} [props.postClickHandler]
  * @return {JSX.Element}
  */
 
@@ -123,6 +124,7 @@ export default function RelatedReport({
   defaultImage = '',
   rwd,
   breakpoint,
+  postClickHandler = () => {},
 }) {
   const checkDataValid = (data) => {
     try {
@@ -158,6 +160,7 @@ export default function RelatedReport({
               defaultImage={defaultImage}
               rwd={rwd}
               breakpoint={breakpoint}
+              postClickHandler={postClickHandler}
             />
           </ul>
         </Container>

--- a/packages/react-components/src/related-report/react-components/related-list.js
+++ b/packages/react-components/src/related-report/react-components/related-list.js
@@ -62,6 +62,7 @@ const ImgBlock = styled.picture`
  * @param {string}      props.defaultImage
  * @param {import('@readr-media/react-image/dist/react-components').Rwd}         [props.rwd]
  * @param {import('@readr-media/react-image/dist/react-components').Breakpoint}  [props.breakpoint]
+ * @param {import("react").MouseEventHandler} props.postClickHandler
  * @return {JSX.Element}
  */
 
@@ -71,8 +72,8 @@ export default function RelatedList({
   defaultImage,
   rwd,
   breakpoint,
+  postClickHandler,
 }) {
-
   //READr 3.0 breakpoint for `@readr-media/react-image`
   const READr_DEFAULT_BREAKPOINT = {
     mobile: '767px',
@@ -87,6 +88,10 @@ export default function RelatedList({
     default: '25vw',
   }
 
+  const handleClick = (post) => {
+    postClickHandler(post)
+  }
+
   return (
     <>
       {postData.map((post, index) => {
@@ -95,6 +100,9 @@ export default function RelatedList({
             key={post.id ? post.id : index}
             className="report-list"
             postAmount={postData.length}
+            onClick={() => {
+              handleClick(post)
+            }}
           >
             <a href={post.link} target="_blank" rel="noopener noreferrer">
               <ImgBlock>


### PR DESCRIPTION
- `RelatedReport` 元件 props：新增 `postClickHandler`

   - 可針對單篇報導設定 onClick 後的觸發事件（ ex: GA event）
   - `postClickHandler` 傳入的 function 參數目前限定為單篇報導的 post data

```
    const PostClick = (post) => {
       console.log(post.name)
    }

    <RelatedReport
      postData={reportsData}
      postClickHandler={PostClick}
    />
```
- 更新 README 中 `postClickHandler` 的使用說明。
- 套件版本升至 `2.1.0-alpha.1`。