### PR TITLE
refactor(election-map): generalize map control interface

### DIFF
--- a/packages/election-map/components/Dashboard.js
+++ b/packages/election-map/components/Dashboard.js
@@ -4,6 +4,11 @@ import { MapContainer } from './MapContainer'
 import { Panels } from './Panels'
 import { Tutorial } from './Tutorial'
 import { useGeoJsons } from '../hook/useGeoJsons'
+import { useState } from 'react'
+import {
+  defaultMapUpperLevelId,
+  defaultRenderingDistrictNames,
+} from '../consts/election-module-pc'
 
 const Wrapper = styled.div`
   position: relative;
@@ -26,7 +31,7 @@ const MoreHint = styled.div`
 
 export const Dashboard = ({
   onElectionChange,
-  mapObject,
+  levelControl,
   election,
   mapData,
   compareMapData,
@@ -40,7 +45,7 @@ export const Dashboard = ({
   compareInfo,
   lastUpdate,
   showLoading,
-  setMapObject,
+  setLevelControl,
   showTutorial,
   setShowTutorial,
   onTutorialEnd,
@@ -48,12 +53,16 @@ export const Dashboard = ({
   hasAnchor,
 }) => {
   const geoJsonsData = useGeoJsons()
+  const [renderingDistrictNames, setRenderingDistrictNames] = useState(
+    defaultRenderingDistrictNames
+  )
+  const [mapUpperLevelId, setMapUpperLevelId] = useState(defaultMapUpperLevelId)
 
   return (
     <Wrapper>
       <Panels
         onElectionChange={onElectionChange}
-        mapObject={mapObject}
+        levelControl={levelControl}
         election={election}
         seatData={seatData}
         infoboxData={infoboxData}
@@ -64,20 +73,24 @@ export const Dashboard = ({
         numberInfo={numberInfo}
         compareInfo={compareInfo}
         lastUpdate={lastUpdate}
+        mapUpperLevelId={mapUpperLevelId}
+        renderingDistrictNames={renderingDistrictNames}
       />
       <MapContainer
         showLoading={showLoading}
         compareInfo={compareInfo}
-        mapObject={mapObject}
+        levelControl={levelControl}
         electionData={mapData}
         compareElectionData={compareMapData}
-        setMapObject={setMapObject}
+        setLevelControl={setLevelControl}
         electionType={election.electionType}
         geoJsonsData={geoJsonsData}
         dashboardInView={dashboardInView}
         mapColor={election.meta?.map?.mapColor}
         yearInfo={yearInfo}
         numberInfo={numberInfo}
+        setMapUpperLevelId={setMapUpperLevelId}
+        setRenderingDistrictNames={setRenderingDistrictNames}
       />
       {!hasAnchor && showTutorial && (
         <Tutorial

--- a/packages/election-map/components/DashboardContainer.js
+++ b/packages/election-map/components/DashboardContainer.js
@@ -38,8 +38,8 @@ export const DashboardContainer = forwardRef(function DashboardContainer(
     compareInfoboxData,
     evcInfo,
     seatData,
-    mapObject,
-    setMapObject,
+    levelControl,
+    setLevelControl,
     onTutorialEnd,
     yearInfo,
     subtypeInfo,
@@ -54,7 +54,7 @@ export const DashboardContainer = forwardRef(function DashboardContainer(
         {loading && <SpinningModal />}
         <Dashboard
           onElectionChange={onElectionChange}
-          mapObject={mapObject}
+          levelControl={levelControl}
           election={election}
           mapData={mapData}
           compareMapData={compareMapData}
@@ -68,7 +68,7 @@ export const DashboardContainer = forwardRef(function DashboardContainer(
           compareInfo={compareInfo}
           lastUpdate={lastUpdate}
           showLoading={showLoading}
-          setMapObject={setMapObject}
+          setLevelControl={setLevelControl}
           showTutorial={showTutorial}
           setShowTutorial={setShowTutorial}
           onTutorialEnd={onTutorialEnd}

--- a/packages/election-map/components/MapContainer.js
+++ b/packages/election-map/components/MapContainer.js
@@ -58,8 +58,8 @@ const defaultTooltip = {
 
 export const MapContainer = ({
   compareInfo,
-  mapObject,
-  setMapObject,
+  levelControl,
+  setLevelControl,
   electionData,
   compareElectionData,
   electionType,
@@ -68,6 +68,8 @@ export const MapContainer = ({
   yearInfo,
   numberInfo,
   geoJsonsData,
+  setMapUpperLevelId,
+  setRenderingDistrictNames,
 }) => {
   const [tooltip, setTooltip] = useState(defaultTooltip)
   const { elementRef, dimension } = useElementDimension()
@@ -102,13 +104,15 @@ export const MapContainer = ({
               dimension={splitDimension}
               geoJsons={geoJsons}
               id="first"
-              mapObject={mapObject}
-              setMapObject={setMapObject}
+              levelControl={levelControl}
+              setLevelControl={setLevelControl}
               setTooltip={setTooltip}
               electionData={electionData}
               electionType={electionType}
               mapColor={mapColor}
               yearInfo={yearInfo}
+              setMapUpperLevelId={setMapUpperLevelId}
+              setRenderingDistrictNames={setRenderingDistrictNames}
             />
             <CompareInfo left={true}>
               {numberInfo?.number
@@ -119,13 +123,15 @@ export const MapContainer = ({
               dimension={splitDimension}
               geoJsons={geoJsons}
               id="second"
-              mapObject={mapObject}
-              setMapObject={setMapObject}
+              levelControl={levelControl}
+              setLevelControl={setLevelControl}
               setTooltip={setTooltip}
               electionData={compareElectionData}
               electionType={electionType}
               mapColor={mapColor}
               yearInfo={yearInfo}
+              setMapUpperLevelId={setMapUpperLevelId}
+              setRenderingDistrictNames={setRenderingDistrictNames}
             />
             <CompareInfo left={false}>
               {compareInfo?.filter?.number
@@ -146,12 +152,14 @@ export const MapContainer = ({
             dimension={dimension}
             geoJsons={geoJsons}
             id="first"
-            mapObject={mapObject}
-            setMapObject={setMapObject}
+            levelControl={levelControl}
+            setLevelControl={setLevelControl}
             setTooltip={setTooltip}
             electionData={electionData}
             electionType={electionType}
             mapColor={mapColor}
+            setMapUpperLevelId={setMapUpperLevelId}
+            setRenderingDistrictNames={setRenderingDistrictNames}
           />
         )}
         <MapTooltip tooltip={tooltip} />

--- a/packages/election-map/components/MapNavigateButton.js
+++ b/packages/election-map/components/MapNavigateButton.js
@@ -31,16 +31,14 @@ const MapLevelControlButton = styled.button`
   }
 `
 
-export const MapNavigateButton = ({ mapObject }) => {
+export const MapNavigateButton = ({ levelControl, mapUpperLevelId }) => {
   const { width } = useWindowDimensions()
   return (
     <MapButtonWrapper>
       <MapLevelControlButton
-        disabled={mapObject.level === 0}
+        disabled={levelControl.level === 0}
         onClick={() => {
-          const target = document.querySelector(
-            `#first-id-${mapObject.upperLevelId}`
-          )
+          const target = document.querySelector(`#first-id-${mapUpperLevelId}`)
           let event = new MouseEvent('click', { bubbles: true })
           target.dispatchEvent(event)
           ReactGA.event({
@@ -53,7 +51,7 @@ export const MapNavigateButton = ({ mapObject }) => {
         回上層
       </MapLevelControlButton>
       <MapLevelControlButton
-        disabled={mapObject.level === 0}
+        disabled={levelControl.level === 0}
         onClick={() => {
           const target = document.querySelector(`#first-id-background`)
           let event = new MouseEvent('click', { bubbles: true })

--- a/packages/election-map/components/MobileDashboard.js
+++ b/packages/election-map/components/MobileDashboard.js
@@ -21,7 +21,7 @@ export const MobileDashboard = ({
   compareInfo,
   lastUpdate,
   showLoading,
-  setMapObject,
+  setLevelControl,
   showTutorial,
   setShowTutorial,
   onTutorialEnd,
@@ -37,7 +37,7 @@ export const MobileDashboard = ({
         mapObject={mapObject}
         electionData={mapData}
         compareElectionData={compareMapData}
-        setMapObject={setMapObject}
+        setLevelControl={setLevelControl}
         electionType={election.electionType}
         geoJsonsData={geoJsonsData}
         mapColor={election.meta?.map?.mapColor}

--- a/packages/election-map/components/Panels.js
+++ b/packages/election-map/components/Panels.js
@@ -66,7 +66,7 @@ const PlaceHolder = styled.div`
 
 export const Panels = ({
   onElectionChange,
-  mapObject,
+  levelControl,
   election,
   infoboxData,
   compareInfoboxData,
@@ -77,10 +77,13 @@ export const Panels = ({
   yearInfo,
   numberInfo,
   lastUpdate,
+  mapUpperLevelId,
+  renderingDistrictNames,
 }) => {
   const { electionType } = election
   const { compareMode } = compareInfo
-  const { countyName, townName, constituencyName, villageName } = mapObject
+  const { countyName, townName, constituencyName, villageName } =
+    renderingDistrictNames
   const locations = [
     countyName,
     townName,
@@ -107,7 +110,10 @@ export const Panels = ({
         )}
         {!numberInfo?.number && (
           <>
-            <MapNavigateButton mapObject={mapObject} />
+            <MapNavigateButton
+              levelControl={levelControl}
+              mapUpperLevelId={mapUpperLevelId}
+            />
             <MapLocations locations={locations} />
             <InfoboxPanels
               infoboxData={infoboxData}
@@ -126,7 +132,8 @@ export const Panels = ({
               ...election.meta.seat,
               year: yearInfo.year?.key,
               location: countyMappingData.find(
-                (countyData) => countyData.countyCode === mapObject.countyId
+                (countyData) =>
+                  countyData.countyCode === levelControl.countyCode
               )?.countyName,
             }}
             data={seatData}
@@ -143,7 +150,10 @@ export const Panels = ({
         {numberInfo?.number && (
           <>
             <BottomPanelWrapper>
-              <MapNavigateButton mapObject={mapObject} />
+              <MapNavigateButton
+                levelControl={levelControl}
+                mapUpperLevelId={mapUpperLevelId}
+              />
               <MapLocations locations={locations} />
               <InfoboxPanels
                 infoboxData={infoboxData}

--- a/packages/election-map/consts/election-module-pc.js
+++ b/packages/election-map/consts/election-module-pc.js
@@ -1,0 +1,18 @@
+/**
+ * Store the displaying district names of the displaying area.
+ * @typedef {Object} RenderingDistrictNames
+ * @property {string} countyName - The name of the county.
+ * @property {string} townName - The name of the town.
+ * @property {string} villageName - The name of the village.
+ * @property {string} constituencyName - The name of the constituency.
+ */
+
+/** @type {RenderingDistrictNames} */
+export const defaultRenderingDistrictNames = {
+  countyName: '',
+  townName: '',
+  villageName: '',
+  constituencyName: '',
+}
+
+export const defaultMapUpperLevelId = 'background'


### PR DESCRIPTION
## Notable Change

- Turn mapObject (map object to control level and districts changes) into levelControl so both map and filter (new mobile control) can share the same interface to modify the level and  districts and get the required election data.
- Move map only state into `Dashboard` which controls by map seperate concerns from mobile filter control.