### PR TITLE
feat(election-map): extend redux hooks, add types

### DIFF
--- a/packages/election-map/hook/useRedux.js
+++ b/packages/election-map/hook/useRedux.js
@@ -1,0 +1,29 @@
+import { useDispatch, useSelector } from 'react-redux'
+/**
+ * @typedef {import('react-redux').TypedUseSelectorHook} TypedUseSelectorHook
+ */
+
+/**
+ * @typedef {import('../store/index').RootState} RootState
+ */
+
+/**
+ * @typedef {import('../store/index').AppDispatch} AppDispatch
+ */
+
+/**
+ * Redux dispatch with types
+ * @see https://react-redux.js.org/using-react-redux/usage-with-typescript
+ * @function
+ * @returns {AppDispatch}
+ */
+const useAppDispatch = useDispatch
+
+/**
+ * Redux selector with types
+ * @see https://react-redux.js.org/using-react-redux/usage-with-typescript
+ * @function
+ * @type {import('react-redux').TypedUseSelectorHook<RootState>}
+ */
+const useAppSelector = useSelector
+export { useAppDispatch, useAppSelector }

--- a/packages/election-map/store/index.js
+++ b/packages/election-map/store/index.js
@@ -1,6 +1,14 @@
 import { configureStore } from '@reduxjs/toolkit'
 import electionReducer from './election-slice'
 
+/**
+ * @typedef {ReturnType<typeof store.getState>} RootState
+ */
+
+/**
+ * @typedef  {typeof store.dispatch} AppDispatch
+ */
+
 const store = configureStore({
   reducer: { election: electionReducer },
 })


### PR DESCRIPTION
## Notable changes

拓展react-redux的`useDispatch`、`useSelector`，將其加上jsDoc。
原本是打算直接使用套件`@types/react-redux`的，但嘗試後發現無效。

## Ref
https://react-redux.js.org/using-react-redux/usage-with-typescript