### PR TITLE
feat(map/votes): add `fetchLegislatorEvcData` by loadLegislatorData

### DIFF
--- a/packages/election-map/utils/fetchElectionData.js
+++ b/packages/election-map/utils/fetchElectionData.js
@@ -242,6 +242,29 @@ export const fetchReferendumEvcData = async ({ yearKey }) => {
 }
 
 /**
+ * Fetch legislator election votes comparison data, need to import the return type from package '@readr-media/react-election-widgets'.
+ * @param {Object} options - Options for fetching legislator evc data.
+ * @param {number} options.yearKey - The key representing the year.
+ * @param {string} options.district - The name of the district (county).
+ * @param {'plainIndigenous' | 'mountainIndigenous' | 'party' | 'district'} options.subtypeKey - The key of the subtype of the election.
+ * @returns {Promise<Object>}
+ */
+export const fetchLegislatorEvcData = async ({
+  yearKey,
+  subtypeKey,
+  district,
+}) => {
+  const loader = new DataLoader({ version: 'v2', apiUrl: gcsBaseUrl })
+  const data = await loader.loadLegislatorData({
+    year: yearKey,
+    subtype: subtypeKey,
+    district,
+  })
+
+  return data
+}
+
+/**
  * Fetch president map data in the specific level (folderName) and code (fileName).
  * @param {Object} options
  * @param {ElectionType} options.electionType - The type of election.


### PR DESCRIPTION
### Notable Changes 
- 使用套件 `@readr-media/react-election-widgets` 內的 `loadLegislatorData` 來建立 `fetchLegislatorEvcData` function，用以取得特定 google cloud storage 路徑內的 json 資料。
- 需傳入 `year` / `subtype` / `district` 參數，其中 subtype 共分為： 'plainIndigenous' | 'mountainIndigenous' | 'party' | 'district' 。如果 subtype 為 'plainIndigenous' | 'mountainIndigenous' | 'party' ，可不用傳入 `district` 參數，在套件內會特別處理，將 `district` 指定為 `all`（全國層級）。

- 相關 PR：https://github.com/readr-media/react/pull/254