### PR TITLE
feat(election-map/utils): add `infoboxData.js`

### DIFF
--- a/packages/election-map/utils/infoboxData.js
+++ b/packages/election-map/utils/infoboxData.js
@@ -1,0 +1,178 @@
+/**
+ *
+ * @typedef {import('./electionsData').ElectionType} ElectionType
+ * @typedef {0 | 1 | 2 | 3} Level
+ * @typedef {'mobile' | 'desktop'} InfoboxType
+ * @typedef {any} ElectionData
+ * @typedef {number} Year
+ * @typedef {import('./electionsData').ModuleData['isRunning']} isRunning
+ * @typedef {import('./electionsData').ModuleData['isStarted']} isStarted
+ */
+
+import { currentYear } from '../consts/electionsConifg'
+
+/**
+ * TODOs:
+ * 1. add type of params `data`
+ * @param {ElectionData} data
+ * @param {Level} level
+ */
+const presidentInfoboxData = (data, level) => {
+  if (!data) {
+    return '無資料'
+  }
+
+  if (!data.profRate && level === 3) {
+    return '目前即時開票無村里資料'
+  }
+  if (data.profRate === null) {
+    return '資料錯誤，請確認'
+  }
+
+  return data
+}
+/**
+ * TODOs:
+ * 1. add type of params `data`
+ * @param {ElectionData} data
+ * @param {Level} level
+ * @param {Year} year
+ * @param {isStarted} isStarted
+ * @param {InfoboxType} infoboxType
+ */
+const mayorInfoboxData = (data, level, year, isStarted, infoboxType) => {
+  if (level === 0) {
+    if (infoboxType === 'mobile') {
+      return ''
+    }
+    return '點擊地圖看更多資料'
+  }
+
+  if (year === 2022 && data === '10020') {
+    return '嘉義市長選舉改期至2022/12/18'
+  }
+
+  if (!isStarted) {
+    return '目前無票數資料'
+  }
+
+  if (!data) {
+    if (year === 2010) {
+      return '2010為直轄市長及直轄市議員選舉，此區無資料'
+    }
+    return '此區無資料'
+  }
+
+  if (year === currentYear && !data.profRate && level === 3) {
+    return '目前即時開票無村里資料'
+  }
+
+  if (data.profRate === null) {
+    return '資料錯誤，請確認'
+  }
+
+  return data
+}
+
+/**
+ * TODOs:
+ * 1. add type of params `data`
+ * @param {ElectionData} data
+ * @param {Level} level
+ * @param {Year} year
+ * @param {isStarted} isStarted
+ * @param {InfoboxType} infoboxType
+ */
+const councilMemberInfoboxData = (
+  data,
+  level,
+  year,
+  isStarted,
+  infoboxType
+) => {
+  if (level === 0) {
+    if (infoboxType === 'mobile') {
+      return ''
+    }
+    return '點擊地圖看更多資料'
+  }
+
+  if (!isStarted) {
+    return '目前無票數資料'
+  }
+
+  if (!data) {
+    if (year === 2010) {
+      return '2010為直轄市長及直轄市議員選舉，此區無資料'
+    }
+    return '此區無資料'
+  }
+
+  if (year === 2022 && level === 3 && data[0].profRate === null) {
+    return '目前即時開票無村里資料'
+  }
+
+  if (data.profRate === null) {
+    console.error(`data error for mayor infoboxData in level ${level}`, data)
+    return '資料錯誤，請確認'
+  }
+
+  return data
+}
+
+/**
+ * TODOs:
+ * 1. add type of params `data`
+ * @param {ElectionData} data
+ * @param {Level} level
+ * @param {Year} year
+ * @param {isStarted} isStarted
+ */
+const referendumInfoboxData = (data, level, year, isStarted) => {
+  if (!isStarted) {
+    return '目前無票數資料'
+  }
+
+  if (!data) {
+    return '此區無資料'
+  }
+
+  if (year === currentYear && !data.profRate && level === 3) {
+    return '目前即時開票無村里資料'
+  }
+
+  if (data.profRate === null) {
+    return '資料錯誤，請確認'
+  }
+
+  return data
+}
+
+/**
+ *
+ * @param {ElectionType} electionsType
+ * @param {InfoboxType} [infoboxType]
+ */
+const getInfoBoxData = (electionsType, infoboxType = 'desktop') => {
+  switch (electionsType) {
+    case 'president':
+      return (data, level) => presidentInfoboxData(data, level)
+
+    case 'mayor':
+      return (data, level, year, isStarted) =>
+        mayorInfoboxData(data, level, year, isStarted, infoboxType)
+    //TODO
+    case 'legislator':
+      return (data) => {
+        return data
+      }
+    case 'councilMember':
+      return (data, level, year, isStarted) =>
+        councilMemberInfoboxData(data, level, year, isStarted, infoboxType)
+    case 'referendum':
+      return (data, level, year, isStarted) =>
+        referendumInfoboxData(data, level, year, isStarted)
+  }
+}
+
+export { getInfoBoxData }


### PR DESCRIPTION
## Notable Change
1. 於`utils` 資料夾中新增`infoboxData.js`，用於處理infobox資料的fallback。
2. 業務邏輯是從元件[`Infobox`](https://github.com/readr-media/Almisael/blob/main/packages/election-map/components/infobox/Infobox.js) 中搬遷而來，並做了以下改動：
  - 使用curry function `getInfoboxData` 生成不同選制所需要的資料處理函式
  - 新增jsDoc
    - 因為electionData較為複雜，目前型別 `ElectionData` 指定為 `any` ，日後有時間另開PR處理
  - 調整不同選制的資料處理函式參數，從傳入一個物件 `({electionData, level}) => {...}` 改為傳入多個值 `(electionData, level) => {...}`
  - 移除目前尚未使用的參數 `isRunning`
  - 在選制市長、縣市議員中，由於手機版dashboard 會直接切換level為1（全國層級），且不會讓使用者選到level為0（全國層級），因此需要不同的fallback處理方式，故新增一參數`infoboxType`，用於處理不同dashboard的infobox資料。