### PR TITLE
fix(election-map/useElectinData): unable execute `target.dispatchEvent` if target is null

### DIFF
--- a/packages/election-map/hook/useElectinData.js
+++ b/packages/election-map/hook/useElectinData.js
@@ -147,8 +147,10 @@ export const useElectionData = (showLoading, showTutorial) => {
           const target = document.querySelector(
             `#first-id-${countyData.countyCode}`
           )
-          let event = new MouseEvent('click', { bubbles: true })
-          target.dispatchEvent(event)
+          if (target) {
+            let event = new MouseEvent('click', { bubbles: true })
+            target.dispatchEvent(event)
+          }
 
           ReactGA.event({
             category: 'Projects',


### PR DESCRIPTION
## Notable Change
在使用手機版dashboard的情境中，`onElectionSelected`並無法取得某個特定地圖DOM元素的資訊，進而造成執行`target.dispatchEvent`時網頁會報錯。
本次PR新增了型別判斷，當target為falsy值時，不執行`target.dispatchEvent`