### PR TITLE
feat(election-map): add EVCpanel in mobile dashboard

### DIFF
--- a/packages/election-map/components/DashboardContainer.js
+++ b/packages/election-map/components/DashboardContainer.js
@@ -53,7 +53,7 @@ export const DashboardContainer = forwardRef(function DashboardContainer(
     return (
       <div ref={ref}>
         {loading && <SpinningModal />}
-        <MobileDashboardNew />
+        <MobileDashboardNew onEvcSelected={onEvcSelected} />
       </div>
     )
   }

--- a/packages/election-map/components/ElectionVoteComparisonPanel.js
+++ b/packages/election-map/components/ElectionVoteComparisonPanel.js
@@ -1,21 +1,39 @@
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { CollapsibleWrapper } from './collapsible/CollapsibleWrapper'
 import widgets from '@readr-media/react-election-widgets'
 import { useAppSelector } from '../hook/useRedux'
 
 const ElectionVotesComparison = widgets.VotesComparison.ReactComponent
 
-const ElectionVotesComparisonWrapper = styled(CollapsibleWrapper)`
+const ElectionVotesComparisonDesktopWrapper = styled(CollapsibleWrapper)`
   position: absolute;
   top: 76px;
   right: 20px;
 `
 
-const StyledEVC = styled(ElectionVotesComparison)`
+const ElectionVotesComparisonMobileWrapper = styled.div`
+  margin-top: 20px;
+`
+const mobileStyle = css`
+  margin: 0 auto;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-bottom: 0 !important;
+
+  overflow: auto;
+  border-radius: 12px;
+  border: 2px solid #000;
+`
+
+const desktopStyle = css`
   width: 320px !important;
   padding-bottom: 0 !important;
   max-height: 568px;
   overflow: auto;
+`
+
+const StyledEVC = styled(ElectionVotesComparison)`
+  ${({ isMobile }) => (isMobile ? mobileStyle : desktopStyle)};
 
   header {
     border-top: unset;
@@ -38,7 +56,13 @@ const StyledEVC = styled(ElectionVotesComparison)`
   }
 `
 
-const ElectionVoteComparisonPanel = ({ onEvcSelected }) => {
+/**
+ *  @param {Object} props
+ *  @param {Function} props.onEvcSelected
+ *  @param {boolean} [props.isMobile]
+ *  @returns {React.ReactElement}
+ */
+const ElectionVoteComparisonPanel = ({ onEvcSelected, isMobile = false }) => {
   const evcScrollTo = useAppSelector(
     (state) => state.election.control.evcScrollTo
   )
@@ -56,25 +80,41 @@ const ElectionVoteComparisonPanel = ({ onEvcSelected }) => {
   } else {
     election = evcData[0]
   }
-  console.log('election', evcData)
-
-  return (
-    election &&
-    (election.districts?.length || election.propositions?.length) && (
-      <ElectionVotesComparisonWrapper title={'縣市議員候選人'}>
-        <StyledEVC
-          electionType={electionType}
-          election={election}
-          device="mobile"
-          theme="electionMap"
-          scrollTo={evcScrollTo}
-          onChange={(selector, value) => {
-            onEvcSelected(value)
-          }}
-        />
-      </ElectionVotesComparisonWrapper>
-    )
+  const shouldShowEVC = Boolean(
+    election && (election.districts?.length || election.propositions?.length)
   )
+  const electionVoteComparisonJsx = isMobile ? (
+    <ElectionVotesComparisonMobileWrapper>
+      <StyledEVC
+        electionType={electionType}
+        election={election}
+        device="mobile"
+        theme="electionMap"
+        scrollTo={evcScrollTo}
+        onChange={(selector, value) => {
+          onEvcSelected(value)
+        }}
+        isMobile={isMobile} //for styled-component
+      />
+    </ElectionVotesComparisonMobileWrapper>
+  ) : (
+    <ElectionVotesComparisonDesktopWrapper title={'縣市議員候選人'}>
+      <StyledEVC
+        electionType={electionType}
+        election={election}
+        device="mobile"
+        theme="electionMap"
+        scrollTo={evcScrollTo}
+        onChange={(selector, value) => {
+          console.log('value', value)
+          onEvcSelected(value)
+        }}
+        isMobile={isMobile} //for styled-component
+      />
+    </ElectionVotesComparisonDesktopWrapper>
+  )
+
+  return shouldShowEVC && <>{electionVoteComparisonJsx}</>
 }
 
 export default ElectionVoteComparisonPanel

--- a/packages/election-map/components/mobile/MobileDashboardNew.js
+++ b/packages/election-map/components/mobile/MobileDashboardNew.js
@@ -1,9 +1,10 @@
 import { useState, useEffect, useMemo } from 'react'
 import { electionNamePairs } from '../../utils/election'
+import styled from 'styled-components'
 import Selector from './Selector'
 import ElectionSelector from './ElectionSelector'
 import ReferendumSelector from './ReferendumSelector'
-import styled from 'styled-components'
+import ElectionVoteComparisonPanel from '../ElectionVoteComparisonPanel'
 
 import YearComparisonMenuBar from './YearComparisonMenuBar'
 import { useDistrictMapping } from '../../hook/useDistrictMapping'
@@ -105,7 +106,7 @@ const ElectionSelectorWrapper = styled(DistrictSelectorWrapper)`
 /**
  * Dashboard for new election map, created in 2023.11.20
  */
-export const MobileDashboardNew = () => {
+export const MobileDashboardNew = ({ onEvcSelected }) => {
   const { districtMapping, hasDistrictMapping } = useDistrictMapping()
   // const [currentElection, setCurrentElection] = useState(ELECTION_TYPE[0])
   const dispatch = useAppDispatch()
@@ -420,6 +421,12 @@ export const MobileDashboardNew = () => {
           </DistrictSelectorWrapper>
           <InfoboxContainer />
         </ContentWrapper>
+        {!compareMode && (
+          <ElectionVoteComparisonPanel
+            onEvcSelected={onEvcSelected}
+            isMobile={true}
+          />
+        )}
       </Wrapper>
     </>
   )

--- a/packages/election-map/components/mobile/MobileDashboardNew.js
+++ b/packages/election-map/components/mobile/MobileDashboardNew.js
@@ -126,7 +126,6 @@ export const MobileDashboardNew = () => {
   const [currentCountyCode, setCurrentCountyCode] = useState('')
   const [currentTownCode, setCurrentTownCode] = useState('')
   const [currentVillageCode, setCurrentVillageCode] = useState('')
-  const [currentOpenSelector, setCurrentOpenSelector] = useState('')
 
   /** @type {CountyData[]} */
   const allCounty = districtMapping.sub
@@ -386,15 +385,11 @@ export const MobileDashboardNew = () => {
             <ElectionSelector
               options={electionNamePairs}
               selectorType="electionType"
-              handleOpenSelector={setCurrentOpenSelector}
-              currentOpenSelector={currentOpenSelector}
             />
             {electionSubTypes && (
               <ElectionSelector
                 selectorType="electionSubType"
                 options={electionSubTypes}
-                handleOpenSelector={setCurrentOpenSelector}
-                currentOpenSelector={currentOpenSelector}
               />
             )}
             {electionsType === 'referendum' && !compareMode ? (
@@ -403,32 +398,23 @@ export const MobileDashboardNew = () => {
           </ElectionSelectorWrapper>
           <DistrictSelectorWrapper>
             <Selector
-              selectorType="districtNationAndCounty"
               options={optionsForFirstDistrictSelector}
               districtCode={currentCountyCode}
               onSelected={handleOnClick}
-              currentOpenSelector={currentOpenSelector}
-              handleOpenSelector={setCurrentOpenSelector}
               placeholderValue="台灣"
             ></Selector>
 
             <Selector
-              selectorType="districtTown"
               options={optionsForSecondDistrictSelector}
               districtCode={currentTownCode}
               onSelected={handleOnClick}
-              currentOpenSelector={currentOpenSelector}
-              handleOpenSelector={setCurrentOpenSelector}
               placeholderValue="-"
             ></Selector>
 
             <Selector
-              selectorType="districtVillage"
               options={optionsForThirdDistrictSelector}
               districtCode={currentVillageCode}
               onSelected={handleOnClick}
-              currentOpenSelector={currentOpenSelector}
-              handleOpenSelector={setCurrentOpenSelector}
               placeholderValue="-"
             ></Selector>
           </DistrictSelectorWrapper>

--- a/packages/election-map/components/mobile/ReferendumSelector.js
+++ b/packages/election-map/components/mobile/ReferendumSelector.js
@@ -7,7 +7,7 @@ import { electionActions } from '../../store/election-slice'
 const SelectedButton = styled.button`
   padding: 2.5px 7.5px;
   width: fit-content;
-  z-index: 10;
+  z-index: 0;
   border-radius: 8px;
   border: 1px solid;
   font-size: 14px;

--- a/packages/election-map/components/mobile/Selector.js
+++ b/packages/election-map/components/mobile/Selector.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components'
-import { useState, useEffect } from 'react'
+import { useState, useRef } from 'react'
+import useClickOutside from '../../hook/useClickOutside'
 const Wrapper = styled.div`
   position: relative;
   text-align: left;
@@ -11,13 +12,7 @@ const Wrapper = styled.div`
 `
 
 const Options = styled.ul`
-  z-index: ${
-    /**
-     * @param {Object} props
-     * @param {boolean} props.shouldShowOptions
-     */
-    ({ shouldShowOptions }) => (shouldShowOptions ? '5' : '2')
-  };
+  z-index: 1;
   background-color: #f2f2f2;
   position: absolute;
   color: #fff;
@@ -68,7 +63,7 @@ const SelectedButton = styled.button`
      * @param {Object} props
      * @param {boolean} props.shouldShowOptions
      */
-    ({ shouldShowOptions }) => (shouldShowOptions ? '6' : '3')
+    ({ shouldShowOptions }) => (shouldShowOptions ? '2' : '0')
   };
   border-radius: 8px;
   background-color: #fff;
@@ -96,38 +91,30 @@ export default function Selector({
   options = [],
   onSelected,
   districtCode,
-  selectorType = '',
   placeholderValue = '',
-  handleOpenSelector,
-  currentOpenSelector,
 }) {
   const [shouldShowOptions, setShouldShowOptions] = useState(false)
-
+  const wrapperRef = useRef(null)
+  useClickOutside(wrapperRef, () => {
+    setShouldShowOptions(false)
+  })
   const hasOptions = options && Array.isArray(options) && options.length
 
   const handleSelectedButtonOnClick = () => {
     setShouldShowOptions((pre) => !pre)
-    shouldShowOptions
-      ? handleOpenSelector(null)
-      : handleOpenSelector(selectorType)
   }
   const handleOptionOnSelected = (option) => {
     onSelected(option.type, option.code)
     setShouldShowOptions(false)
-    handleOpenSelector(null)
   }
   const currentSelectDistrictName = hasOptions
     ? options.find((option) => option.code === districtCode)?.name ??
       placeholderValue
     : null
-  useEffect(() => {
-    if (currentOpenSelector !== selectorType) {
-      setShouldShowOptions(false)
-    }
-  }, [currentOpenSelector, selectorType])
+
   return (
     <>
-      <Wrapper>
+      <Wrapper ref={wrapperRef}>
         <SelectedButton
           shouldShowOptions={shouldShowOptions}
           onClick={handleSelectedButtonOnClick}
@@ -138,7 +125,7 @@ export default function Selector({
           <i className="triangle"></i>
         </SelectedButton>
         {shouldShowOptions && hasOptions && (
-          <Options shouldShowOptions={shouldShowOptions}>
+          <Options>
             {options.map((option, index) => (
               <OptionItem
                 isSelected={option.name === currentSelectDistrictName}

--- a/packages/election-map/package.json
+++ b/packages/election-map/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@readr-media/react-election-votes-comparison": "2.0.0-beta.25",
-    "@readr-media/react-election-widgets": "1.0.6",
+    "@readr-media/react-election-widgets": "1.1.1-alpha.2",
     "@readr-media/react-live-blog": "1.1.7",
     "@reduxjs/toolkit": "^1.9.7",
     "axios": "^1.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1809,10 +1809,10 @@
     serialize-javascript "^6.0.0"
     uuid "^8.3.2"
 
-"@readr-media/react-election-widgets@1.0.6":
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@readr-media/react-election-widgets/-/react-election-widgets-1.0.6.tgz#dc3a7912b504f7cc79cadb06c9239e9b0968f2ff"
-  integrity sha512-KVy+tYufGz3gHPHTqGfDoWYYauU/r6uaG2W8Zti4R8UOGvTmBvsWDWy91+xNsBY7xTGmElYBFtoLETyvQxkqQA==
+"@readr-media/react-election-widgets@1.1.1-alpha.2":
+  version "1.1.1-alpha.2"
+  resolved "https://registry.yarnpkg.com/@readr-media/react-election-widgets/-/react-election-widgets-1.1.1-alpha.2.tgz#91bfb89e4fae9b766b90ee4c08fc8f7302916384"
+  integrity sha512-z8a6KgY/ryvpSfnjzbkNJYGFal0qt9GAhQKmZ1dPvCHOCycRD0xBOjzgnCjjkhu7kfljIJJoyoqtXUWcHydR3w==
   dependencies:
     "@twreporter/errors" "^1.1.1"
     axios "^0.27.2"


### PR DESCRIPTION
## Notable Change
1. 調整各篩選器，調整`z-index`避免高於 evc選區選擇器的燈箱，並刪除不必要的state。
2. 套件 `@readr-media/react-election-widgets` 升版。
3. 導入元件`ElectionVoteComparisonPanel` 於手機版dashboard。