### PR TITLE
refactor(election-map): seperate selectors and related business logic

### DIFF
--- a/packages/election-map/components/mobile/DistrictSelectors.js
+++ b/packages/election-map/components/mobile/DistrictSelectors.js
@@ -1,0 +1,377 @@
+import { useState, useEffect, useMemo } from 'react'
+
+import styled from 'styled-components'
+import Selector from './Selector'
+
+import { useDistrictMapping } from '../../hook/useDistrictMapping'
+
+import { useAppSelector } from '../../hook/useRedux'
+import { useAppDispatch } from '../../hook/useRedux'
+import { electionActions } from '../../store/election-slice'
+/**
+ * @typedef {Object} NationData
+ * @property {string} name
+ * @property {string} code
+ * @property {'nation'} type
+ * @property {CountyData[]} sub
+ */
+
+/**
+ * @typedef {Object} CountyData
+ * @property {string} name
+ * @property {string} code
+ * @property {'county'} type
+ * @property {TownData[]} sub
+ */
+/**
+ * @typedef {Object} TownData
+ * @property {string} name
+ * @property {string} code
+ * @property {'town'} type
+ * @property {VillageData[]} sub
+ */
+/**
+ * @typedef {Object} VillageData
+ * @property {string} name
+ * @property {string} code
+ * @property {'village'} type
+ * @property {null} sub
+ */
+
+/**
+ * @typedef {'nation' | 'county' | 'town' | 'village' | 'constituency'} DistrictType
+ */
+
+const Wrapper = styled.div`
+  width: 100%;
+  margin: 0 auto;
+  text-align: center;
+  padding: 12px 16px;
+  min-height: 100vh;
+  background-color: ${
+    /**
+     * @param {Object} props
+     * @param {boolean} [props.isCompareMode]
+     */
+    ({ isCompareMode }) => (isCompareMode ? '#E9E9E9' : 'transparent')
+  };
+`
+
+const DistrictSelectorWrapper = styled.div`
+  display: flex;
+  margin: 8px auto 4px;
+  width: 100%;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  justify-content: left;
+  gap: 12px;
+`
+
+export default function DistrictSelectors({}) {
+  const { districtMapping, hasDistrictMapping } = useDistrictMapping()
+  const allCounty = districtMapping.sub
+  const [currentDistrictType, setCurrentDistrictType] = useState('nation')
+
+  const dispatch = useAppDispatch()
+  const { changeLevelControl, resetLevelControl } = electionActions
+
+  const [currentCountyCode, setCurrentCountyCode] = useState('')
+  const [currentTownCode, setCurrentTownCode] = useState('')
+  const [currentVillageCode, setCurrentVillageCode] = useState('')
+  const electionsType = useAppSelector(
+    (state) => state.election.config.electionType
+  )
+
+  const currentElectionSubType = useAppSelector(
+    (state) => state.election.control.subtype
+  )
+  const year = useAppSelector((state) => state.election.control.year)
+
+  const isConstituency =
+    electionsType === 'legislator' && currentElectionSubType.key === 'normal'
+
+  const allTown = getAllTown(currentCountyCode)
+
+  const allVillage = getAllVillage(currentTownCode)
+
+  function getAllTown(code) {
+    if (currentDistrictType === 'nation') {
+      return []
+    }
+    if (!code) {
+      return []
+    }
+
+    return allCounty?.find((item) => item.code === code)?.sub ?? []
+  }
+
+  function getAllVillage(code) {
+    if (
+      !code ||
+      currentDistrictType === 'nation' ||
+      currentDistrictType === 'county'
+    ) {
+      return []
+    }
+
+    return allTown?.find((item) => item.code === code)?.sub ?? []
+  }
+
+  /**
+   *
+   * @param {DistrictType} type
+   * @param {string} code
+   */
+  const handleOnClick = (
+    type = districtMapping.type,
+    code = districtMapping.code
+  ) => {
+    setCurrentDistrictType(type)
+    switch (type) {
+      case 'nation':
+        setCurrentCountyCode('')
+        setCurrentTownCode('')
+        setCurrentVillageCode('')
+        break
+      case 'county':
+        setCurrentCountyCode(code)
+        setCurrentTownCode('')
+        setCurrentVillageCode('')
+        break
+      case 'town':
+        setCurrentTownCode(code)
+        setCurrentVillageCode('')
+        break
+      case 'village':
+        setCurrentVillageCode(code)
+        break
+      default:
+        break
+    }
+  }
+
+  const optionsForFirstDistrictSelector = useMemo(() => {
+    switch (electionsType) {
+      case 'mayor':
+      case 'councilMember':
+      case 'legislator':
+        return [...districtMapping.sub]
+      case 'referendum':
+      case 'president':
+        return [
+          {
+            type: districtMapping.type,
+            code: districtMapping.code,
+            name: districtMapping.name,
+          },
+          ...districtMapping.sub,
+        ]
+
+      default:
+        break
+    }
+  }, [electionsType, districtMapping])
+  const optionsForSecondDistrictSelector = useMemo(() => {
+    if (currentCountyCode) {
+      return [
+        { type: 'county', code: currentCountyCode, name: '-' },
+        ...allTown,
+      ]
+    }
+    return [...allTown]
+  }, [allTown, currentCountyCode])
+  const optionsForThirdDistrictSelector = useMemo(() => {
+    if (currentTownCode) {
+      return [{ type: 'town', code: currentTownCode, name: '-' }, ...allVillage]
+    }
+    return [...allVillage]
+  }, [allVillage, currentTownCode])
+
+  // //clean up
+  // useEffect(() => {
+  //   if (currentDistrictType === 'nation') {
+  //     setCurrentCountyCode('')
+  //     setCurrentTownCode('')
+  //     // setCurrentConstituencyCode('')
+  //     setCurrentVillageCode('')
+  //   } else if (currentDistrictType === 'county') {
+  //     setCurrentTownCode('')
+
+  //     setCurrentVillageCode('')
+  //   } else if (currentDistrictType === 'town') {
+  //     setCurrentVillageCode('')
+  //   }
+  // }, [currentDistrictType, setCurrentCountyCode])
+  useEffect(() => {
+    // 為什麼需要將不相關的state `year`與 `electionType` 加入dependency?
+    // 因為會希望當年份或選制改變時，也能夠觸發dispatch `changeLevelControl`，避免infobox無法出現。
+    // 這個workaround違反了useEffect對dependency的設計原則，日後有時間需要調整。
+    let level = 0
+    switch (currentDistrictType) {
+      case 'nation':
+        dispatch(resetLevelControl())
+        return
+      case 'county':
+        level = 1
+        dispatch(
+          changeLevelControl({
+            level,
+            countyCode: currentCountyCode,
+            townCode: '',
+            villageCode: '',
+            constituencyCode: '',
+            activeCode: currentCountyCode,
+          })
+        )
+        break
+      case 'town':
+        level = 2
+        dispatch(
+          changeLevelControl({
+            level,
+            countyCode: currentCountyCode,
+            townCode: currentTownCode,
+            villageCode: '',
+            constituencyCode: '',
+            activeCode: currentTownCode,
+          })
+        )
+        break
+      // case 'constituency':
+      //   level = 2
+      //   dispatch(
+      //     changeLevelControl({
+      //       level,
+      //       countyCode: currentCountyCode,
+      //       townCode: '',
+      //       villageCode: '',
+      //       constituencyCode: currentConstituencyCode,
+      //       activeCode: currentConstituencyCode,
+      //     })
+      //   )
+      //   break
+      case 'village':
+        level = 3
+        dispatch(
+          changeLevelControl({
+            level: 3,
+            countyCode: currentCountyCode,
+            townCode: currentTownCode,
+            villageCode: currentVillageCode,
+            constituencyCode: '',
+            activeCode: currentVillageCode,
+          })
+        )
+        break
+      default:
+        break
+    }
+  }, [
+    dispatch,
+    year,
+    electionsType,
+    currentElectionSubType,
+    resetLevelControl,
+    currentDistrictType,
+    changeLevelControl,
+    currentCountyCode,
+    currentTownCode,
+    currentVillageCode,
+    isConstituency,
+  ])
+  useEffect(() => {
+    if (!hasDistrictMapping) {
+      return
+    }
+
+    switch (electionsType) {
+      case 'mayor':
+        if (!currentCountyCode) {
+          setCurrentDistrictType('county')
+          setCurrentCountyCode(allCounty?.[0]?.code)
+        }
+        break
+      case 'councilMember':
+        if (!currentCountyCode) {
+          setCurrentDistrictType('county')
+          setCurrentCountyCode(allCounty?.[0]?.code)
+        }
+
+        break
+      //TODO: 中央選舉
+      case 'president':
+        break
+      case 'legislator':
+        if (!currentCountyCode) {
+          setCurrentDistrictType('county')
+          setCurrentCountyCode(allCounty?.[0]?.code)
+        }
+        break
+      //todo: 公投
+      case 'referendum':
+        break
+      default:
+        break
+    }
+  }, [
+    hasDistrictMapping,
+    electionsType,
+    allCounty,
+    allTown,
+    currentCountyCode,
+    setCurrentCountyCode,
+    setCurrentDistrictType,
+  ])
+
+  const test = () => {
+    dispatch(
+      changeLevelControl({
+        level: 3,
+        countyCode: currentCountyCode,
+        townCode: currentTownCode,
+        villageCode: currentVillageCode,
+        constituencyCode: '',
+        activeCode: currentVillageCode,
+      })
+    )
+  }
+  if (!hasDistrictMapping) {
+    return <Wrapper>loading....</Wrapper>
+  }
+  return (
+    <>
+      <DistrictSelectorWrapper>
+        <Selector
+          options={optionsForFirstDistrictSelector}
+          districtCode={currentCountyCode}
+          onSelected={handleOnClick}
+          placeholderValue="台灣"
+        ></Selector>
+
+        <Selector
+          options={optionsForSecondDistrictSelector}
+          districtCode={currentTownCode}
+          onSelected={handleOnClick}
+          placeholderValue="-"
+        ></Selector>
+
+        <Selector
+          options={optionsForThirdDistrictSelector}
+          districtCode={currentVillageCode}
+          onSelected={handleOnClick}
+          placeholderValue="-"
+        ></Selector>
+      </DistrictSelectorWrapper>
+
+      <>
+        <button onClick={test}>測試DistrictSelector</button>
+        <div>currentDistrictType:{currentDistrictType}</div>
+        <div>currentCountyCode:{currentCountyCode}</div>
+        {/* <div>currentConstituencyCode:{currentConstituencyCode}</div> */}
+        <div>currentTownCode:{currentTownCode}</div>
+        <div>currentVillageCode:{currentVillageCode}</div>
+      </>
+    </>
+  )
+}

--- a/packages/election-map/components/mobile/DistrictWithAreaSelectors.js
+++ b/packages/election-map/components/mobile/DistrictWithAreaSelectors.js
@@ -1,0 +1,329 @@
+import { useState, useEffect, useMemo } from 'react'
+
+import styled from 'styled-components'
+import Selector from './Selector'
+
+import { useDistrictMapping } from '../../hook/useDistrictMapping'
+
+import { useAppSelector } from '../../hook/useRedux'
+import { useAppDispatch } from '../../hook/useRedux'
+import { electionActions } from '../../store/election-slice'
+/**
+ * @typedef {Object} NationData
+ * @property {string} name
+ * @property {string} code
+ * @property {'nation'} type
+ * @property {CountyData[]} sub
+ */
+
+/**
+ * @typedef {Object} CountyData
+ * @property {string} name
+ * @property {string} code
+ * @property {'county'} type
+ * @property {TownData[]} sub
+ */
+/**
+ * @typedef {Object} TownData
+ * @property {string} name
+ * @property {string} code
+ * @property {'town'} type
+ * @property {VillageData[]} sub
+ */
+/**
+ * @typedef {Object} VillageData
+ * @property {string} name
+ * @property {string} code
+ * @property {'village'} type
+ * @property {null} sub
+ */
+
+/**
+ * @typedef {'nation' | 'county' | 'town' | 'village' | 'constituency'} DistrictType
+ */
+
+const Wrapper = styled.div`
+  width: 100%;
+  margin: 0 auto;
+  text-align: center;
+  padding: 12px 16px;
+  min-height: 100vh;
+  background-color: ${
+    /**
+     * @param {Object} props
+     * @param {boolean} [props.isCompareMode]
+     */
+    ({ isCompareMode }) => (isCompareMode ? '#E9E9E9' : 'transparent')
+  };
+`
+
+const DistrictSelectorWrapper = styled.div`
+  display: flex;
+  margin: 8px auto 4px;
+  width: 100%;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  justify-content: left;
+  gap: 12px;
+`
+
+export default function DistrictWithAreaSelectors({}) {
+  const { districtMapping, hasDistrictMapping } = useDistrictMapping()
+  const allCounty = districtMapping.sub
+  const [currentCountyCode, setCurrentCountyCode] = useState('')
+  const [currentDistrictType, setCurrentDistrictType] = useState('nation')
+
+  const dispatch = useAppDispatch()
+  const { changeLevelControl, resetLevelControl } = electionActions
+
+  const [currentConstituencyCode, setCurrentConstituencyCode] = useState('')
+  const [currentConstituencyVillageCode, setCurrentConstituencyVillageCode] =
+    useState('')
+  const electionsType = useAppSelector(
+    (state) => state.election.config.electionType
+  )
+
+  const currentElectionSubType = useAppSelector(
+    (state) => state.election.control.subtype
+  )
+  const year = useAppSelector((state) => state.election.control.year)
+
+  const isConstituency =
+    electionsType === 'legislator' && currentElectionSubType.key === 'normal'
+
+  const allTown = getAllTown(currentCountyCode)
+  const allVillage = getAllVillage(currentConstituencyCode)
+
+  function getAllTown(code) {
+    if (currentDistrictType === 'nation') {
+      return []
+    }
+    if (!code) {
+      return []
+    }
+
+    return allCounty?.find((item) => item.code === code)?.sub ?? []
+  }
+
+  function getAllVillage(code) {
+    if (
+      !code ||
+      currentDistrictType === 'nation' ||
+      currentDistrictType === 'county'
+    ) {
+      return []
+    }
+
+    return allTown?.find((item) => item.code === code)?.sub ?? []
+  }
+
+  /**
+   *
+   * @param {DistrictType} type
+   * @param {string} code
+   */
+  const handleOnClick = (type, code) => {
+    setCurrentDistrictType(type)
+    switch (type) {
+      case 'nation':
+        setCurrentCountyCode('')
+        setCurrentConstituencyCode('')
+        setCurrentConstituencyVillageCode('')
+        break
+      case 'county':
+        setCurrentCountyCode(code)
+        setCurrentConstituencyCode('')
+        setCurrentConstituencyVillageCode('')
+        break
+      case 'constituency':
+        setCurrentConstituencyCode(code)
+        setCurrentConstituencyVillageCode('')
+        break
+      case 'village':
+        setCurrentConstituencyVillageCode(code)
+        break
+      default:
+        break
+    }
+  }
+
+  const optionsForFirstDistrictSelector = useMemo(() => {
+    return allCounty
+  }, [allCounty])
+  const optionsForSecondDistrictSelector = useMemo(() => {
+    if (currentCountyCode) {
+      return [
+        { type: 'county', code: currentCountyCode, name: '-' },
+        ...allTown,
+      ]
+    }
+    return [...allTown]
+  }, [allTown, currentCountyCode])
+  const optionsForThirdDistrictSelector = useMemo(() => {
+    if (currentConstituencyCode) {
+      return [
+        { type: 'constituency', code: currentConstituencyCode, name: '-' },
+        ...allVillage,
+      ]
+    }
+    return [...allVillage]
+  }, [allVillage, currentConstituencyCode])
+
+  useEffect(() => {
+    if (!hasDistrictMapping) {
+      return
+    }
+    // 為什麼需要將不相關的state `year`與 `electionType` 加入dependency?
+    // 因為會希望當年份或選制改變時，也能夠觸發dispatch `changeLevelControl`，避免infobox無法出現。
+    // 這個workaround違反了useEffect對dependency的設計原則，日後有時間需要調整。
+    let level = 0
+    switch (currentDistrictType) {
+      case 'nation':
+        dispatch(resetLevelControl())
+        return
+      case 'county':
+        level = 1
+        dispatch(
+          changeLevelControl({
+            level,
+            countyCode: currentCountyCode,
+            townCode: '',
+            villageCode: '',
+            constituencyCode: '',
+            activeCode: currentCountyCode,
+          })
+        )
+        break
+
+      case 'constituency':
+        level = 2
+        dispatch(
+          changeLevelControl({
+            level,
+            countyCode: currentCountyCode,
+            townCode: '',
+            villageCode: '',
+            constituencyCode: currentConstituencyCode,
+            activeCode: currentConstituencyCode,
+          })
+        )
+        break
+      case 'village':
+        level = 3
+        dispatch(
+          changeLevelControl({
+            level,
+            countyCode: currentCountyCode,
+            townCode: '',
+            villageCode: currentConstituencyVillageCode,
+            constituencyCode: currentConstituencyCode,
+            activeCode: currentConstituencyVillageCode,
+          })
+        )
+        break
+
+      default:
+        break
+    }
+  }, [
+    dispatch,
+    resetLevelControl,
+    electionsType,
+    year,
+    currentDistrictType,
+    changeLevelControl,
+    currentCountyCode,
+    currentConstituencyCode,
+    currentConstituencyVillageCode,
+    hasDistrictMapping,
+  ])
+  useEffect(() => {
+    if (!hasDistrictMapping) {
+      return
+    }
+
+    switch (electionsType) {
+      case 'mayor':
+        break
+      case 'councilMember':
+        break
+
+      case 'president':
+        break
+      case 'legislator':
+        if (!currentCountyCode) {
+          setCurrentDistrictType('county')
+          setCurrentCountyCode(allCounty?.[0]?.code)
+        }
+        break
+      //todo: 公投
+      case 'referendum':
+        break
+      default:
+        break
+    }
+  }, [
+    hasDistrictMapping,
+    electionsType,
+    allCounty,
+    allTown,
+    currentCountyCode,
+    setCurrentCountyCode,
+    setCurrentDistrictType,
+    currentConstituencyCode,
+    isConstituency,
+  ])
+
+  const test = () => {
+    dispatch(
+      changeLevelControl({
+        level: 3,
+        countyCode: currentCountyCode,
+        townCode: currentConstituencyCode,
+        villageCode: currentConstituencyVillageCode,
+        constituencyCode: currentConstituencyCode,
+        activeCode: currentConstituencyVillageCode,
+      })
+    )
+  }
+  if (!hasDistrictMapping) {
+    return <Wrapper>loading....</Wrapper>
+  }
+  return (
+    <>
+      <DistrictSelectorWrapper>
+        <Selector
+          options={optionsForFirstDistrictSelector}
+          districtCode={currentCountyCode}
+          onSelected={handleOnClick}
+          placeholderValue="台灣"
+        ></Selector>
+
+        <Selector
+          options={optionsForSecondDistrictSelector}
+          districtCode={currentConstituencyCode}
+          onSelected={handleOnClick}
+          placeholderValue="-"
+        ></Selector>
+
+        <Selector
+          options={optionsForThirdDistrictSelector}
+          districtCode={currentConstituencyVillageCode}
+          onSelected={handleOnClick}
+          placeholderValue="-"
+        ></Selector>
+      </DistrictSelectorWrapper>
+
+      <>
+        <button onClick={test}>測試DistrictWithAreaSelector</button>
+        <div>currentDistrictType:{currentDistrictType}</div>
+        <div>currentCountyCode:{currentCountyCode}</div>
+        <div>currentConstituencyCode:{currentConstituencyCode}</div>
+        <div>
+          currentConstituencyVillageCode:{currentConstituencyVillageCode}
+        </div>
+      </>
+    </>
+  )
+}

--- a/packages/election-map/components/mobile/ElectionSelector.js
+++ b/packages/election-map/components/mobile/ElectionSelector.js
@@ -125,7 +125,9 @@ export default function ElectionSelector({ options = [], selectorType }) {
         dispatch(electionActions.changeElection(option.electionType))
       }
     } else if (selectorType === 'electionSubType') {
-      dispatch(electionActions.changeSubtype(option))
+      if (currentSubType.key !== option.key) {
+        dispatch(electionActions.changeSubtype(option))
+      }
     }
 
     setShouldShowOptions(false)

--- a/packages/election-map/components/mobile/SeletorsContainer.js
+++ b/packages/election-map/components/mobile/SeletorsContainer.js
@@ -1,0 +1,124 @@
+import styled from 'styled-components'
+import { electionNamePairs } from '../../utils/election'
+import ElectionSelector from './ElectionSelector'
+import ReferendumSelector from './ReferendumSelector'
+import DistrictSelectors from './DistrictSelectors'
+import DistrictWithAreaSelectors from './DistrictWithAreaSelectors'
+import { useDistrictMapping } from '../../hook/useDistrictMapping'
+
+import { useAppSelector } from '../../hook/useRedux'
+
+/**
+ * @typedef {Object} NationData
+ * @property {string} name
+ * @property {string} code
+ * @property {'nation'} type
+ * @property {CountyData[]} sub
+ */
+
+/**
+ * @typedef {Object} CountyData
+ * @property {string} name
+ * @property {string} code
+ * @property {'county'} type
+ * @property {TownData[]} sub
+ */
+/**
+ * @typedef {Object} TownData
+ * @property {string} name
+ * @property {string} code
+ * @property {'town'} type
+ * @property {VillageData[]} sub
+ */
+/**
+ * @typedef {Object} VillageData
+ * @property {string} name
+ * @property {string} code
+ * @property {'village'} type
+ * @property {null} sub
+ */
+
+/**
+ * @typedef {'nation' | 'county' | 'town' | 'village' | 'constituency'} DistrictType
+ */
+
+const Wrapper = styled.div`
+  width: 100%;
+  margin: 0 auto;
+  text-align: center;
+  padding: 12px 16px;
+  min-height: 100vh;
+  background-color: ${
+    /**
+     * @param {Object} props
+     * @param {boolean} [props.isCompareMode]
+     */
+    ({ isCompareMode }) => (isCompareMode ? '#E9E9E9' : 'transparent')
+  };
+`
+
+const DistrictSelectorWrapper = styled.div`
+  display: flex;
+  margin: 8px auto 4px;
+  width: 100%;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  justify-content: left;
+  gap: 12px;
+`
+const ElectionSelectorWrapper = styled(DistrictSelectorWrapper)`
+  justify-content: left;
+  gap: 12px;
+  margin: 40px auto 0;
+`
+
+/**
+ * TODO:
+ * 1. Need refactor corresponding business logic of districts in different election type.
+ * 2. Rewrite state to make it more clear and clean, remove unneeded useEffect if need.
+ */
+export default function SelectorWrapper() {
+  const { hasDistrictMapping } = useDistrictMapping()
+
+  const electionsType = useAppSelector(
+    (state) => state.election.config.electionType
+  )
+  const electionSubTypes = useAppSelector(
+    (state) => state.election.config.subtypes
+  )
+  const currentElectionSubtype = useAppSelector(
+    (state) => state.election.control.subtype
+  )
+  const compareInfo = useAppSelector((state) => state.election.compare.info)
+  const { compareMode } = compareInfo
+  const shouldShowDistrictWithAreaSelectors =
+    electionsType === 'legislator' && currentElectionSubtype.key === 'normal'
+  if (!hasDistrictMapping) {
+    return <Wrapper>loading....</Wrapper>
+  }
+  return (
+    <>
+      <ElectionSelectorWrapper>
+        <ElectionSelector
+          options={electionNamePairs}
+          selectorType="electionType"
+        />
+        {electionSubTypes && (
+          <ElectionSelector
+            selectorType="electionSubType"
+            options={electionSubTypes}
+          />
+        )}
+        {electionsType === 'referendum' && !compareMode ? (
+          <ReferendumSelector></ReferendumSelector>
+        ) : null}
+      </ElectionSelectorWrapper>
+      {shouldShowDistrictWithAreaSelectors ? (
+        <DistrictWithAreaSelectors key="DistrictWithAreaSelectors"></DistrictWithAreaSelectors>
+      ) : (
+        <DistrictSelectors key="DistrictSelectors"></DistrictSelectors>
+      )}
+    </>
+  )
+}

--- a/packages/election-map/utils/infoboxData.js
+++ b/packages/election-map/utils/infoboxData.js
@@ -152,7 +152,7 @@ const legislatorInfoboxData = (data, level, year, isStarted, infoboxType) => {
     return '此區無資料'
   }
 
-  if (year === 2024 && level === 3 && data[0].profRate === null) {
+  if (year === currentYear && level === 3 && data[0].profRate === null) {
     return '目前即時開票無村里資料'
   }
 


### PR DESCRIPTION
## Notable Change
1. 將手機版dashboard中的篩選器元件移至新的元件，並區分區域立委選區篩選器（`DistrictWithAreaSelectors`）與一般行政區篩選器（`DistrictSelectors`）。
2. 之所以如此區分，是因為區域立委選區與一般行政區的state不同，在原本的寫法會多有衝突，造成非預期的狀況發生。為了避免上述情形發生，且簡化手機版dashboard元件的邏輯，故拆分。
3. 微調選制篩選器邏輯，在選取同一個subtype時不會觸發dispatch `changeSubtype`