### PR TITLE
refactor(election-map): pc infobox support note property

### DIFF
--- a/packages/election-map/components/infobox/Infobox.js
+++ b/packages/election-map/components/infobox/Infobox.js
@@ -1,6 +1,16 @@
 import styled from 'styled-components'
 import { getInfoBoxData } from '../../utils/infoboxData'
 
+/**
+ *  Inside infobox data, a summary object or district object may have a note object
+ *  which is special description to the current infobox data.
+ *  The note object only exists when needed and the text must exist to describe the situation.
+ *  The note.displayVotes flag is used for infobox component to decide if the infobox data should still be displayed.
+ * @typedef {Object} InfoboxNote
+ * @property {string} text - note content to add additional description to the current infobox data
+ * @property {boolean} displayVotes - a flag to indicate whether the following infobox data should display or not
+ */
+
 const InfoboxWrapper = styled.div`
   font-family: 'Noto Sans TC', sans-serif;
   padding: 16px 22px;
@@ -42,6 +52,10 @@ const PresidentCandidateParty = styled.div`
 
 const InfoboxText = styled.p`
   margin: 0;
+`
+
+const InfoboxNote = styled.p`
+  margin-bottom: 28px;
 `
 
 const ElectedIcon = styled.div`
@@ -133,6 +147,18 @@ const PresidentInfobox = ({ level, data, isRunning, isCurrentYear }) => {
     )
   }
 
+  /** @type {InfoboxNote | undefined} */
+  const note = data.note
+
+  // check the type of InfoboxNote for the business logic of the note
+  if (note?.text && !note?.displayVotes) {
+    return (
+      <InfoboxScrollWrapper>
+        <InfoboxNote>{note.text}</InfoboxNote>
+      </InfoboxScrollWrapper>
+    )
+  }
+
   const isCurrentYearRunningJsx = isCurrentYear ? (
     isRunning ? (
       <RunningHint>開票中</RunningHint>
@@ -146,6 +172,7 @@ const PresidentInfobox = ({ level, data, isRunning, isCurrentYear }) => {
   const { profRate, candidates } = data
   return (
     <InfoboxScrollWrapper>
+      {note?.text && <InfoboxNote>{note.text}</InfoboxNote>}
       <PresidentTitle>
         {level === 0 && '總'}投票率 {profRate}% {isCurrentYearRunningJsx}
       </PresidentTitle>
@@ -207,9 +234,22 @@ const MayorInfobox = ({ level, data, isRunning, isCurrentYear }) => {
     )
   }
 
+  /** @type {InfoboxNote | undefined} */
+  const note = data.note
+
+  // check the type of InfoboxNote for the business logic of the note
+  if (note?.text && !note?.displayVotes) {
+    return (
+      <InfoboxScrollWrapper>
+        <InfoboxNote>{note.text}</InfoboxNote>
+      </InfoboxScrollWrapper>
+    )
+  }
+
   const { profRate, candidates } = data
   return (
     <InfoboxScrollWrapper>
+      {note?.text && <InfoboxNote>{note.text}</InfoboxNote>}
       <MayorTitle>
         {level === 1 && '總'}投票率 {profRate}%
         {isCurrentYear ? (
@@ -317,10 +357,24 @@ const NormalLegislatorInfobox = ({ level, data, isRunning, isCurrentYear }) => {
     <></>
   )
 
+  // check the type of InfoboxNote for the business logic of the note
+  // use one of the note
+  /** @type {InfoboxNote | undefined} */
+  const note = data.find((data) => !!data.note?.text)?.note
+
+  if (note?.text && !note?.displayVotes) {
+    return (
+      <InfoboxScrollWrapper>
+        <InfoboxNote>{note.text}</InfoboxNote>
+      </InfoboxScrollWrapper>
+    )
+  }
+
   if (level === 1) {
     const districts = data
     return (
       <InfoboxScrollWrapper>
+        {note?.text && <InfoboxNote>{note.text}</InfoboxNote>}
         <HintWrapper>{isCurrentYearRunningJsx}</HintWrapper>
         {districts.map(({ county, area, range, candidates, profRate }) => {
           const legislatorPrefix = county + area
@@ -363,6 +417,7 @@ const NormalLegislatorInfobox = ({ level, data, isRunning, isCurrentYear }) => {
 
   return (
     <InfoboxScrollWrapper>
+      {note?.text && <InfoboxNote>{note.text}</InfoboxNote>}
       {data.map((district) => {
         const { candidates, profRate, type, county, town, area } = district
         const legislatorPrefix = county + town + area + type
@@ -452,8 +507,22 @@ const IndigenousLegislatorInfobox = ({ data, isRunning, isCurrentYear }) => {
 
   let infoboxData = Array.isArray(data) ? data : [data]
 
+  // check the type of InfoboxNote for the business logic of the note
+  // use one of the note
+  /** @type {InfoboxNote | undefined} */
+  const note = infoboxData.find((data) => !!data.note?.text)?.note
+
+  if (note?.text && !note?.displayVotes) {
+    return (
+      <InfoboxScrollWrapper>
+        <InfoboxNote>{note.text}</InfoboxNote>
+      </InfoboxScrollWrapper>
+    )
+  }
+
   return (
     <InfoboxScrollWrapper>
+      {note?.text && <InfoboxNote>{note.text}</InfoboxNote>}
       {infoboxData.map((district) => {
         const { candidates, profRate, type, county, town, area } = district
         const legislatorPrefix = county + town + area + type
@@ -540,8 +609,22 @@ const PartyLegislatorInfobox = ({ data, isRunning, isCurrentYear }) => {
   )
   let infoboxData = Array.isArray(data) ? data : [data]
 
+  // check the type of InfoboxNote for the business logic of the note
+  // use one of the note
+  /** @type {InfoboxNote | undefined} */
+  const note = infoboxData.find((data) => !!data.note?.text)?.note
+
+  if (note?.text && !note?.displayVotes) {
+    return (
+      <InfoboxScrollWrapper>
+        <InfoboxNote>{note.text}</InfoboxNote>
+      </InfoboxScrollWrapper>
+    )
+  }
+
   return (
     <InfoboxScrollWrapper>
+      {note?.text && <InfoboxNote>{note.text}</InfoboxNote>}
       {/* 
           Although all party legislator data should only contain one district to render,
           use map function to handle cause all legislator infobox data is filled in array.
@@ -708,9 +791,22 @@ const CouncilMemberInfobox = ({ level, data, isRunning, isCurrentYear }) => {
   }
 
   if (level === 1) {
+    /** @type {InfoboxNote | undefined} */
+    const note = data.note
+
+    // check the type of InfoboxNote for the business logic of the note
+    if (note?.text && !note?.displayVotes) {
+      return (
+        <InfoboxScrollWrapper>
+          <InfoboxNote>{note.text}</InfoboxNote>
+        </InfoboxScrollWrapper>
+      )
+    }
+
     const { districts } = data
     return (
       <InfoboxScrollWrapper>
+        {note?.text && <InfoboxNote>{note.text}</InfoboxNote>}
         {isCurrentYear ? (
           isRunning ? (
             <HintWrapper>
@@ -759,6 +855,19 @@ const CouncilMemberInfobox = ({ level, data, isRunning, isCurrentYear }) => {
             </CouncilMemberDistrict>
           )
         })}
+      </InfoboxScrollWrapper>
+    )
+  }
+
+  // check the type of InfoboxNote for the business logic of the note
+  // use one of the note
+  /** @type {InfoboxNote | undefined} */
+  const note = data.find((data) => !!data.note?.text)?.note
+
+  if (note?.text && !note?.displayVotes) {
+    return (
+      <InfoboxScrollWrapper>
+        <InfoboxNote>{note.text}</InfoboxNote>
       </InfoboxScrollWrapper>
     )
   }
@@ -856,7 +965,12 @@ const CouncilMemberInfobox = ({ level, data, isRunning, isCurrentYear }) => {
     }
   })
 
-  return <InfoboxScrollWrapper>{councilMembers}</InfoboxScrollWrapper>
+  return (
+    <InfoboxScrollWrapper>
+      {note?.text && <InfoboxNote>{note.text}</InfoboxNote>}
+      {councilMembers}
+    </InfoboxScrollWrapper>
+  )
 }
 
 const ReferendumPassWrapper = styled.span`
@@ -900,8 +1014,22 @@ const ReferendumInfobox = ({ data, isRunning, isCurrentYear }) => {
   const { profRate, adptVictor, agreeRate, disagreeRate } = data
   const noResult = adptVictor !== 'Y' && adptVictor !== 'N'
   const pass = adptVictor === 'Y'
+
+  /** @type {InfoboxNote | undefined} */
+  const note = data.note
+
+  // check the type of InfoboxNote for the business logic of the note
+  if (note?.text && !note?.displayVotes) {
+    return (
+      <InfoboxScrollWrapper>
+        <InfoboxNote>{note.text}</InfoboxNote>
+      </InfoboxScrollWrapper>
+    )
+  }
+
   return (
     <InfoboxScrollWrapper>
+      {note?.text && <InfoboxNote>{note.text}</InfoboxNote>}
       {isCurrentYear ? (
         isRunning ? (
           <HintWrapper>


### PR DESCRIPTION
## Notable Change

infobox 桌機版會多判斷 infoboxData 是否帶有 note object，note object 為特殊需求，只有在需要的時候才會夾帶在 mapData 中，`text` property 主要用來顯示說明性文字，像是"嘉義市長選舉改期至2022/12/18"針對 2022 年嘉義市長選舉的投票狀況進行描述，而 `displayVotes` 則是在進行描述的同時，是否一併顯示原本的 infobox data，同樣以上述嘉義市長選舉改期為例子，2022 年選舉當下因為嘉義市市長改期所以不會產生選舉結果，因此 `displayVotes` 的值會是 false 以忽略該市選舉資料的呈現，而在 2022/12/18 進行嘉義市市長選舉後 (更精確來說，有嘉義市市長選舉結果後)，同樣會顯示描述性字眼，但應同時呈現選舉結果，所以 `displayVotes` 就會是 true。

以下是 note 的資料結構，一般情況下不會有 note 這個 key。
```
"note": {
    "text": "測試用 note， infobox data 應該被顯示出來",
    "displayVotes": true
}
```

本 PR 將這個 rule 應用到各類選舉當中，日後任何選舉只要需要有額外說明文字皆可以在資料成面新增這個 object 來讓 infobox 直接使用。