### PR TITLE
chore(map): update `react-election-widgets` version

### DIFF
--- a/packages/election-map/package.json
+++ b/packages/election-map/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@readr-media/react-election-votes-comparison": "2.0.0-beta.25",
-    "@readr-media/react-election-widgets": "1.1.1-alpha.7",
+    "@readr-media/react-election-widgets": "1.1.1",
     "@readr-media/react-live-blog": "1.1.13",
     "@reduxjs/toolkit": "^1.9.7",
     "axios": "^1.1.3",

--- a/packages/election-map/package.json
+++ b/packages/election-map/package.json
@@ -11,7 +11,6 @@
     "export": "next build && next export"
   },
   "dependencies": {
-    "@readr-media/react-election-votes-comparison": "2.0.0-beta.25",
     "@readr-media/react-election-widgets": "1.1.1",
     "@readr-media/react-live-blog": "1.1.13",
     "@reduxjs/toolkit": "^1.9.7",

--- a/packages/election-map/utils/fetchElectionData.js
+++ b/packages/election-map/utils/fetchElectionData.js
@@ -162,7 +162,7 @@ const SCDataLoader = widgets.SeatChart.DataLoader
  * @returns {Promise<SeatsData>} A promise that resolves to the fetched seat data.
  */
 export const fetchCouncilMemberSeatData = async ({ yearKey, countyCode }) => {
-  const loader = new SCDataLoader({ version: 'v1', apiUrl: gcsBaseUrl })
+  const loader = new SCDataLoader({ apiUrl: gcsBaseUrl })
   const data = await loader.loadCouncilMemberData({ year: yearKey, countyCode })
   return data
 }
@@ -178,7 +178,7 @@ export const fetchLegislatorSeatData = async ({
   yearKey,
   countyCode,
 }) => {
-  const loader = new SCDataLoader({ version: 'v1', apiUrl: gcsBaseUrl })
+  const loader = new SCDataLoader({ apiUrl: gcsBaseUrl })
   let data
   switch (subtype) {
     case 'all':

--- a/yarn.lock
+++ b/yarn.lock
@@ -1833,10 +1833,10 @@
     serialize-javascript "^6.0.0"
     uuid "^8.3.2"
 
-"@readr-media/react-election-widgets@1.1.1-alpha.7":
-  version "1.1.1-alpha.7"
-  resolved "https://registry.yarnpkg.com/@readr-media/react-election-widgets/-/react-election-widgets-1.1.1-alpha.7.tgz#aa04bbe9da7efb40abd3d9175ec458636722a2c2"
-  integrity sha512-NFVqBhQRQfPcB4xv4XmDmRRWSuQVmxBdHyEjtxQ5Wbk/KdoXgVxmLX5m9kdI+ijxt3r1kynHvrHOATe+NiWaqg==
+"@readr-media/react-election-widgets@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@readr-media/react-election-widgets/-/react-election-widgets-1.1.1.tgz#19895f678be3f7b925e416e495187d6776c418e2"
+  integrity sha512-pBPGC92rZBn3HHgFtGA9Ea3kns2ZTMgNYmz7hUHz7DVEb9O+4EHhaLEN/rYxReDLNotZQpDVnba1KTCU4qcedw==
   dependencies:
     "@twreporter/errors" "^1.1.1"
     axios "^0.27.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1821,18 +1821,6 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.21.tgz#5de5a2385a35309427f6011992b544514d559aa1"
   integrity sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==
 
-"@readr-media/react-election-votes-comparison@2.0.0-beta.25":
-  version "2.0.0-beta.25"
-  resolved "https://registry.yarnpkg.com/@readr-media/react-election-votes-comparison/-/react-election-votes-comparison-2.0.0-beta.25.tgz#0c8e1f63b4f7b5356ffa85f62a76cb854e351bce"
-  integrity sha512-fqI+YJI1Z/4DPB9T5+BE6+1Iy4VQrTU6PVriaIpriJmR2ECn9Y7Vi0GhoFZwYtBg+8qixh+oohZv4gGAmL8Rbw==
-  dependencies:
-    "@twreporter/errors" "^1.1.1"
-    axios "0.27.2"
-    lodash "^4.17.21"
-    regenerator-runtime "^0.13.9"
-    serialize-javascript "^6.0.0"
-    uuid "^8.3.2"
-
 "@readr-media/react-election-widgets@1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@readr-media/react-election-widgets/-/react-election-widgets-1.1.1.tgz#19895f678be3f7b925e416e495187d6776c418e2"
@@ -2824,7 +2812,7 @@ axe-core@^4.4.3:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.5.0.tgz#6efe2ecdba205fcc9d7ddb3d48c2cf630f70eb5e"
   integrity sha512-4+rr8eQ7+XXS5nZrKcMO/AikHL0hVqy+lHWAnE3xdHl+aguag8SOQ6eEqLexwLNWgXIMfunGuD3ON1/6Kyet0A==
 
-axios@0.27.2, axios@^0.27.2:
+axios@^0.27.2:
   version "0.27.2"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
   integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
@@ -7175,7 +7163,7 @@ regenerator-runtime@^0.13.10, regenerator-runtime@^0.13.11:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
-regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.9:
+regenerator-runtime@^0.13.4:
   version "0.13.10"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz#ed07b19616bcbec5da6274ebc75ae95634bfc2ee"
   integrity sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw==


### PR DESCRIPTION
- 更新 `@readr-media/react-election-widgets` 至正式版本 `1.1.1`。
- 因應上述版本中`seat-chart` 參數的修改，移除專案內既有 `SCDataLoader` 內的 `version` 參數。未來使用套件內的 `SeatChart.DataLoader` 時，一律不需再傳入 `version` 參數。
- 移除不再使用的套件：`@readr-media/react-election-votes-comparison`
- Related PR：https://github.com/readr-media/react/pull/268