### PR TITLE
feat: referendum update

### DIFF
--- a/packages/election-map/components/InfoboxPanel.js
+++ b/packages/election-map/components/InfoboxPanel.js
@@ -5,6 +5,7 @@ import { electionNamePairs } from '../utils/election'
 import { Infobox } from './infobox/Infobox'
 import { useAppSelector } from '../hook/useRedux'
 import gtag from '../utils/gtag'
+import { isRecallSubtype } from '../utils/recallValidator'
 
 const Wrppaer = styled.div`
   width: 320px;
@@ -77,6 +78,7 @@ export const InfoboxPanel = ({
           subtype={subtype}
           isCurrentYear={year.key === currentYear}
           year={year.key}
+          isRecall={subtype?.key ? isRecallSubtype(subtype.key) : false}
         />
       </InfoboxWrapper>
     </Wrppaer>

--- a/packages/election-map/components/infobox/Infobox.js
+++ b/packages/election-map/components/infobox/Infobox.js
@@ -18,7 +18,14 @@ import { imageLoader } from '../../loader'
 const InfoboxWrapper = styled.div`
   font-family: 'Noto Sans TC', sans-serif;
   padding: 16px 22px;
-  height: 626px;
+  height: ${
+    /**
+     *
+     * @param {Object} props - Component props
+     * @param {boolean} props.isRecall - Flag to determine the height of the infobox
+     */
+    ({ isRecall }) => (isRecall ? '626px' : '202px')
+  };
   overflow: auto;
 
   @media (max-width: 1024px) {
@@ -1377,11 +1384,12 @@ const ReferendumInfobox = ({ data, isRunning, isCurrentYear }) => {
  * @param {Object} props
  * @param {import('../../utils/electionsData').InfoboxData} props.data
  * @param {boolean} props.isCurrentYear
+ * @param {boolean} props.isRecall
  * @param {number} props.year
  * @param {import('../../consts/electionsConfig').ElectionSubtype} props.subtype
  * @returns {JSX.Element}
  */
-export const Infobox = ({ data, isCurrentYear, year, subtype }) => {
+export const Infobox = ({ data, isCurrentYear, year, subtype, isRecall }) => {
   const { electionType, level, electionData, isRunning, isStarted } = data
   let infobox
 
@@ -1486,5 +1494,5 @@ export const Infobox = ({ data, isCurrentYear, year, subtype }) => {
       break
   }
 
-  return <InfoboxWrapper>{infobox}</InfoboxWrapper>
+  return <InfoboxWrapper isRecall={isRecall}>{infobox}</InfoboxWrapper>
 }

--- a/packages/election-map/consts/electionsConfig.js
+++ b/packages/election-map/consts/electionsConfig.js
@@ -401,6 +401,19 @@ export const electionsConfig = [
           },
         ],
       },
+      {
+        key: 2025,
+        subType: [],
+        numbers: [
+          {
+            year: 2025,
+            key: '21',
+            name: '公投第21案',
+            detail:
+              '您是否同意第三核能發電廠經主管機關同意確認無安全疑慮後，繼續運轉？',
+          },
+        ],
+      },
     ],
     meta: {
       evc: { wrapperTitle: '全國性公投' },


### PR DESCRIPTION
## Description

  This PR enhances the Infobox and InfoboxPanel components to support different layouts for
  recall elections.

  Previously, the Infobox component had a fixed height, which was not suitable for recall
  elections that require more space to display detailed information. This change introduces a
  dynamic height adjustment based on the election subtype.

 ## Changes

   * `components/InfoboxPanel.js`:
       * Detects if the current election subtype is a recall election using the isRecallSubtype
         utility.
       * Passes a new isRecall boolean prop to the Infobox component.

   * `components/infobox/Infobox.js`:
       * The InfoboxWrapper styled-component now dynamically sets its height based on the
         isRecall prop.
       * The height is set to 626px for recall elections and 202p for all other election types.

   * `consts/electionsConfig.js`:
       * Adds configuration for the 2025 referendum (Public Referendum Case #21).